### PR TITLE
verify gluster_infra_fw_state is defined

### DIFF
--- a/roles/firewall_config/tasks/main.yml
+++ b/roles/firewall_config/tasks/main.yml
@@ -5,7 +5,7 @@
         state: started
         name: firewalld
 
-- name: check if required variablea are set
+- name: check if required variables are set
   fail:
     msg: "gluster_infra_fw_state is undefined"
   when: gluster_infra_fw_state is not defined


### PR DESCRIPTION
Changes in  gluster-ansible-infra/roles/firewall_config/tasks/main.yml, added task to verify if variable gluster_infra_fw_state is defined.