### PR TITLE
Round vg_pesize to upper number

### DIFF
--- a/roles/backend_setup/tasks/vg_create.yml
+++ b/roles/backend_setup/tasks/vg_create.yml
@@ -41,7 +41,7 @@
 
 - name: Set the PE size
   set_fact:
-     vg_pesize: "{{ vg_pe | int }}"
+     vg_pesize: "{{ vg_pe | int + 0.5 | round | int }}"
   when: >
      gluster_infra_disktype == 'RAID6' or
      gluster_infra_disktype == 'RAID10'


### PR DESCRIPTION
Round vg_pesize to upper number when diskcount * stripesize is less than 1 MiB. At least while lvg module is not accepting KiB.