### PR TITLE
allow more lvm configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ respective sub-roles directory.
 | gluster_infra_thick_lvs || UNDEF | Optional. Needed only if thick volume has to be created. This is a dictionary with vgname, lvname, and size as keys. See below for example |
 | gluster_infra_mount_devices | | UNDEF | This is a dictionary with mount values. path, vgname, and lvname are the keys. |
 | gluster_infra_cache_vars | | UNDEF | This variable contains list of dictionaries for setting up LV cache. Variable has following keys: vgname, cachedisk, cachethinpoolname, cachelvname, cachelvsize, cachemetalvname, cachemetalvsize, cachemode. The keys are explained in more detail below|
+|gluster_infra_lvm|  | UNDEF | This variable contains a dictionary, which defines how lvm should autoextend thinpool's
+|fstrim_service|| UNDEF | This variable contains a dictionary, which enables when and how often a TRIM command should be send to the mounted fs, which support this
 
 
 #### VDO Variable
@@ -102,9 +104,11 @@ For Example:
 gluster_infra_volume_groups:
    - { vgname: 'volgroup1', pvname: '/dev/sdb' }
    - { vgname: 'volgroup2', pvname: '/dev/mapper/vdo_device1' }
-   - { vgname: 'volgroup3', pvname: '/dev/sdc,/dev/sdd'
+   - { vgname: 'volgroup3', pvname: '/dev/sdc,/dev/sdd' }
 ```
 
+* vgname: Required, string defining the VG name to belong to
+* pvname: Required, string defining the device paths to pass to the lvg module. Currently the behavior of passing multiple devices is undefined, but should be handled corectly in simple cases
 
 #### Logical Volume variable
 -----------------------
@@ -117,7 +121,18 @@ For Example:
 gluster_infra_lv_logicalvols:
    - { vgname: 'vg_vdb', thinpool: 'foo_thinpool', lvname: 'vg_vdb_thinlv', lvsize: '500G' }
    - { vgname: 'vg_vdc', thinpool: 'bar_thinpool', lvname: 'vg_vdc_thinlv', lvsize: '500G' }
+   - { vgname: 'ans_vg', thinpool: 'ans_thinpool4', lvname: 'ans_thinlv5', lvsize: '1G', pvs: '/dev/sdd1,/dev/sdg1', opts: '--type raid1', meta_opts: '--type raid1', meta_pvs: '/dev/sde1,/dev/sdf1' }
 ```
+
+* vgname: Required, string defining the VG name to belong to
+* lvname: Required, string defining the name of the LV
+* thinpool: Required, string defining the name the thinpool this LV belongs to
+* lvsize: Optional, Default 100%, size of LV
+* pvs: Optional, Default empty, the physical devices the LV should be placed on
+* opts: Optional, Default empty, additional parameters being passed to the lvm module, which uses those in lvcreate
+* meta_pvs: Optional, Default empty, the physical devices the metadata volume should be placed on
+* meta_opts: Optional, Default empty, additional parameters to pass to lvcreate for creating the metadata volume
+* skipfs: Optional Boolean, Default no. When yes no XFS filesystem will be created on the LV
 
 #### Thick LV variable
 -----------------------
@@ -131,46 +146,65 @@ For Example:
 gluster_infra_thick_lvs:
    - { vgname: 'vg_sdb', lvname: 'thick_lv_1', size: '500G' }
    - { vgname: 'vg_sdc', lvname: 'thick_lv_2', size: '100G' }
+   - { vgname: 'ans_vg', lvname: 'ans_thick2_vdo', size: '9G', atboot: yes, skipfs: yes, opts: "", pvs: '/dev/sdd1,/dev/sdg1' }
 ```
+
+* vgname: Required, string defining the VG name to belong to
+* lvname: Required, string defining the name of the LV
+* lvsize: Optional, Default 100%, size of LV
+* pvs: Optional, Default empty, the physical devices the LV should be placed on
+* opts: Optional, Default empty, additional parameters being passed to the lvm module, which uses those in lvcreate
+* skipfs: Optional Boolean, Default no. When yes no XFS filesystem will be created on the LV
+* atboot: Optional Boolean, Default no. When yes the parameter "rd.lvm.lv=DM" will be added to the kernel parameters in grub
 
 #### Thinpool variable
 ----------------------
 | Name                     |Choices| Default value         | Comments                          |
 |--------------------------|-------|-----------------------|-----------------------------------|
-| gluster_infra_thinpools || UNDEF | This is a list of hash/dictionary variables, with keys: vgname, thinpoolname, thinpoolsize, and poolmetadatasize. See below for example. |
+| gluster_infra_thinpools || UNDEF | This is a list of hash/dictionary variables, with keys: vgname, thinpoolname, thinpoolsize, poolmetadatasize, pvs, opts, meta_pvs and meta_opts. See below for example. |
 
 
 ```
 gluster_infra_thinpools:
   - {vgname: 'vg_vdb', thinpoolname: 'foo_thinpool', thinpoolsize: '10G', poolmetadatasize: '1G' }
   - {vgname: 'vg_vdc', thinpoolname: 'bar_thinpool', thinpoolsize: '20G', poolmetadatasize: '1G' }
+  - {vgname: 'ans_vg', thinpoolname: 'ans_thinpool', thinpoolsize: '1G', poolmetadatasize: '15M', opts: "", pvs: '/dev/sdd1,/dev/sdg1', meta_opts: '--type raid1', meta_pvs: '/dev/sde1,/dev/sdf1' }
 ```
 
 * poolmetadatasize: Metadata size for LV, recommended value 16G is used by default. That value can be overridden by setting the variable. Include the unit [G\|M\|K]
 * thinpoolname: Can be ignored, a name is formed using the given vgname followed by '_thinpool'
 * vgname: Name of the volume group this thinpool should belong to.
+* thinpoolsize: The size of the thinpool
+* pvs: Optional, Default empty, the physical devices the LV should be placed on
+* opts: Optional, Default empty, additional parameters being passed to the lvm module, which uses those in lvcreate
+* meta_pvs: Optional, Default empty, the physical devices the metadata volume should be placed on
+* meta_opts: Optional, Default empty, additional parameters to pass to lvcreate for creating the metadata volume
 
 
 #### Variables for setting up cache
 -----------------------------------------
 | Name                     |Choices| Default value         | Comments                          |
 |--------------------------|-------|-----------------------|-----------------------------------|
-| gluster_infra_cache_vars | | UNDEF | This is a dictionary with keys: vgname, cachedisk, cachethinpoolname, cachelvname, cachelvsize, cachemetalvname, cachemetalvsize, cachemode |
+| gluster_infra_cache_vars | | UNDEF | This is a dictionary with keys: vgname, cachedisk, cachetarget/cachethinpoolname, cachelvname, cachelvsize, cachemetalvname, cachemetalvsize, cachemode |
 
 ```
 vgname - The vg which will be extended to setup cache.
 cachedisk - The SSD disk which will be used to setup cache. Complete path, for eg: /dev/sdd
-cachethinpoolname - The existing thinpool on the volume group mentioned above.
+cachethinpoolname - (deprecated, see: cachetarget) The existing thinpool on the volume group mentioned above.
+cachetarget - THe target thinpool or thick LV that should be cached
 cachelvname - Logical volume name for setting up cache, an lv with this name is created.
 cachelvsize - Cache logical volume size
 cachemetalvname - Meta LV name.
 cachemetalvsize - Meta LV size
 cachemode - Cachemode, default is writethrough.
+meta_pvs - Optional, Default empty, the physical devices the metadata volume should be placed on
+meta_opts - Optional, Default empty, additional parameters to pass to lvcreate for creating the metadata volume
 ```
 
 For example:
 ```
    - { vgname: 'vg_vdb', cachedisk: '/dev/vdd', cachethinpoolname: 'foo_thinpool', cachelvname: 'cachelv', cachelvsize: '20G', cachemetalvname: 'cachemeta', cachemetalvsize: '100M', cachemode: 'writethrough' }
+   - { vgname: 'ans_vg', cachedisk: '/dev/sde1,/dev/sdf1', cachetarget: 'ans_thick', cachelvname: 'cache-ans_thinpool', cachelvsize: '10G', cachemetalvsize: '1G', meta_opts: '--type raid1', meta_pvs: '/dev/sde1,/dev/sdh1', cachemode: 'writethrough' }
 ```
 
 
@@ -186,8 +220,45 @@ gluster_infra_mount_devices:
         - { path: '/mnt/thinv', vgname: <vgname>, lvname: <lvname> }
 ```
 
+#### Variables for configuring LVM auto extend for thin pools
+-----------------------------------------
+| Name                     |Choices| Default value         | Comments                          |
+|--------------------------|-------|-----------------------|-----------------------------------|
+| gluster_infra_lvm | | UNDEF | This is a dictionary to configure the LVM auto extend. autoexpand_threshold and autoexpand_percentage are the keys. |
 
+```
+For example:
+gluster_infra_lvm: {
+      autoexpand_threshold: 70,
+      autoexpand_percentage: 15,
+   }
+```
 
+* autoexpand_threshold: Optional default empty, the threshold in percentage when LVM should try to expand the thinpool (see lvm.conf)
+* autoexpand_percentage: Optional default empty, the percentage the thinpool should be expanded with (see lvm.conf)
+
+#### Variables for configuring fstimer service and timer
+-----------------------------------------
+| Name                     |Choices| Default value         | Comments                          |
+|--------------------------|-------|-----------------------|-----------------------------------|
+| fstrim_service | | UNDEF | This is a dictionary to configure the fstrim service. enabled and schedule are the keys. |
+
+```
+For example:
+fstrim_service: {
+      enabled: yes,
+      schedule: {         
+         hour: "{{ range(1, 4) | random() }}"
+      }
+   }
+```
+
+* enabled: Boolean default no. When yes the fstrim.timer unit will be enabled
+* schedule: Optional dictionary, to set the timer, by default doesn't override the schedule. can be usefull to not trigger the trim at the same time across the cluster. optionable subkeys;
+   * dow: Optional String, specifying the Dow of Week as required by the systemd calander. When empty a random day is chosen.
+   * hour: Optional int, default a random hour, setting the hour the fstrim should run
+   * minute: Optional int, default a random minute, setting the minute the fstrim should run
+   * second: Optional int, default a random second, setting the second the fstrim should run
 
 Example Playbook
 ----------------
@@ -221,6 +292,20 @@ Configure the ports and services related to GlusterFS, create logical volumes an
      gluster_infra_diskcount: 10
      # Stripe unit size always in KiB
      gluster_infra_stripe_unit_size: 128
+
+     # enable lvm auto-extend feature so that when the pool is at 70% it will be extended with 15%
+     gluster_infra_lvm: {
+      autoexpand_threshold: 70,
+      autoexpand_percentage: 15,
+     }
+   
+     # enable fstrim service so the TRIM command is executed once in a while to clean either ssd or thin/vdo volumes
+     fstrim_service: {
+       enabled: yes,
+       schedule: {         
+         hour: "{{ range(1, 4) | random() }}"
+       }
+      }
 
      # Variables for creating volume group
      gluster_infra_volume_groups:

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ gluster_infra_thinpools:
 vgname - The vg which will be extended to setup cache.
 cachedisk - The SSD disk which will be used to setup cache. Complete path, for eg: /dev/sdd
 cachethinpoolname - (deprecated, see: cachetarget) The existing thinpool on the volume group mentioned above.
-cachetarget - THe target thinpool or thick LV that should be cached
+cachetarget - The target thinpool or thick LV that should be cached
 cachelvname - Logical volume name for setting up cache, an lv with this name is created.
 cachelvsize - Cache logical volume size
 cachemetalvname - Meta LV name.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ respective sub-roles directory.
 | gluster_infra_thick_lvs || UNDEF | Optional. Needed only if thick volume has to be created. This is a dictionary with vgname, lvname, and size as keys. See below for example |
 | gluster_infra_mount_devices | | UNDEF | This is a dictionary with mount values. path, vgname, and lvname are the keys. |
 | gluster_infra_cache_vars | | UNDEF | This variable contains list of dictionaries for setting up LV cache. Variable has following keys: vgname, cachedisk, cachethinpoolname, cachelvname, cachelvsize, cachemetalvname, cachemetalvsize, cachemode. The keys are explained in more detail below|
-|gluster_infra_lvm|  | UNDEF | This variable contains a dictionary, which defines how lvm should autoextend thinpool's
+|gluster_infra_lvm|  | UNDEF | This variable contains a dictionary, which defines how lvm should autoextend thinpools
 |fstrim_service|| UNDEF | This variable contains a dictionary, which enables when and how often a TRIM command should be send to the mounted fs, which support this
 
 -----------------

--- a/roles/backend_setup/README.md
+++ b/roles/backend_setup/README.md
@@ -85,7 +85,7 @@ For Example:
 gluster_infra_volume_groups:
    - { vgname: 'volgroup1', pvname: '/dev/sdb' }
    - { vgname: 'volgroup2', pvname: '/dev/mapper/vdo_device1' }
-   - { vgname: 'volgroup3', pvname: '/dev/sdc,/dev/sdd'
+   - { vgname: 'volgroup3', pvname: '/dev/sdc,/dev/sdd' }
 ```
 
 #### Logical Volume variable

--- a/roles/backend_setup/tasks/cache_setup.yml
+++ b/roles/backend_setup/tasks/cache_setup.yml
@@ -14,6 +14,56 @@
      pv_options: "--dataalignment 256K"
   with_items: "{{ gluster_infra_cache_vars }}"
 
+- name: Check if cachepool exists
+  shell: "lvs --options 'lv_attr' -a --noheadings {{item.vgname}}/{{item.cachelvname}}| sed 's/^ *//;s/$//'"    
+  register: checkpool_attrs
+  with_items: "{{ gluster_infra_cache_vars }}"
+  tags: debug
+
+- name: Check if cachepool-metadata exists
+  shell: "lvs --options 'lv_attr' -a --noheadings {{item.vgname}}/{{item.cachelvname}}_cmeta| sed 's/^ *//;s/$//'"    
+  register: checkpoolmeta_attrs
+  with_items: "{{ gluster_infra_cache_vars }}"  
+  tags: debug
+
+- name: Check if logical data volume
+  shell: lvs -a --options 'lv_attr' --noheading {{item.vgname}}/{{item.cachethinpoolname}} | sed 's/^ *//;s/$//'
+  register: datapool_attrs
+  with_items: "{{ gluster_infra_cache_vars }}"  
+  tags: debug
+
+- name: Check if logical volume exists and is backed by the cache pool
+#   shell: >
+#       lvs -a --options 'data_lv' --noheading {{item.vgname}}/{{item.cachethinpoolname}} 2>/dev/null | awk '{ gsub(/^\[/,"",$1);gsub(/\]$/,"",$1);if(length($1)>0){ print "{{item.vgname}}/"$1}}' |
+#       xargs -r lvs -a --noheadings --options 'pool_lv'| sed 's/^ *//;s/$//'
+  shell: >
+      lvs -a --options 'data_lv,pool_lv' --separator "|" --noheadings  {{item.vgname}}/{{item.cachethinpoolname}} 2>/dev/null| 
+         awk -F '|'   '{ gsub(/^\s*\[/,"",$1);gsub(/\]\|?$/,"",$1);if(length($2)>0){ print "echo "$2}else if(length($1)>0){ print "lvs -a --noheadings --options 'pool_lv' {{item.vgname}}/"$1}}'|
+         bash|sed 's/^ *//;s/$//'
+  register: datapoolcache_attrs
+  with_items: "{{ gluster_infra_cache_vars }}"  
+  tags: debug  
+
+- debug: 
+   var: checkpool_attrs
+   verbosity: 1
+  tags: debug
+
+- debug: 
+   var: item.1.stdout.find(item.0.cachelvname)
+   verbosity: 1
+  loop: "{{ gluster_infra_cache_vars|zip(datapoolcache_attrs.results)|list }}"
+  tags: debug
+
+- debug: 
+   msg: "exec convert {{ item.0.cachelvname }} - {{ item.1.stdout }} - {{ item.1.stdout.find(item.0.cachelvname) }} = {{ index }}= {{datapool_attrs.results[index]}}"
+   verbosity: 0
+  loop: "{{ gluster_infra_cache_vars|zip(datapoolcache_attrs.results)|list }}"
+  loop_control:
+   index_var: index
+  #when: item.1.stdout.find(item.0.cachelvname) == -1
+  tags: debug
+
 - name: Change attributes of LV
   lvol:
      state: present
@@ -22,46 +72,65 @@
      opts: " --zero n "
   with_items: "{{ gluster_infra_cache_vars }}"
 
+
 - name: Create LV for cache
   lvol:
      state: present
-     vg: "{{ item.vgname }}"
-     lv: "{{ item.cachelvname }}"
-     size: "{{ item.cachelvsize }}"
-  with_items: "{{ gluster_infra_cache_vars }}"
+     vg: "{{ item.0.vgname }}"
+     lv: "{{ item.0.cachelvname }}"
+     size: "{{ item.0.cachelvsize }}"
+  #with_items: "{{ gluster_infra_cache_vars }}"
+  #Operation not permitted on hidden LV ans_vg/cache-ans_thinpool2.
+  #Sorry, no shrinking of cache-ans_thinpool3 without force=yes.
+  when: item.1.stdout.find('C') != 0
+  loop: "{{ gluster_infra_cache_vars | zip(checkpool_attrs.results) | list }}"
+  tags: debug
 
 - name: Create metadata LV for cache
   lvol:
      state: present
-     vg: "{{ item.vgname }}"
-     lv: "{{ item.cachemetalvname }}"
-     size: "{{ item.cachemetalvsize }}"
-  with_items: "{{ gluster_infra_cache_vars }}"
-  when: item.cachemetalvname is defined
+     vg: "{{ item.0.vgname }}"
+     lv: "{{ item.0.cachemetalvname }}"
+     size: "{{ item.0.cachemetalvsize }}"
+  #with_items: "{{ gluster_infra_cache_vars }}"
+  loop: "{{ gluster_infra_cache_vars | zip(checkpoolmeta_attrs.results) | list }}"
+  when: item.0.cachemetalvname is defined and item.1.stdout.find('e') != 0
+  tags: debug
 
+#Command on LV ans_vg/cache-ans_thinpool2 does not accept LV type cachepool
 - name: Convert logical volume to a cache pool LV
   command: >
-     lvconvert -y --type cache-pool --poolmetadata {{ item.cachemetalvname }}
+     lvconvert -y --type cache-pool 
+        {% if item.0.cachemetalvname is defined %} 
+         --poolmetadata {{ item.0.cachemetalvname }} 
+        {% endif %}
         --poolmetadataspare n
-        --cachemode {{item.cachemode | default('writethrough')}}
-        "/dev/{{item.vgname}}/{{item.cachelvname}}"
-  with_items: "{{ gluster_infra_cache_vars }}"
-  when: item.cachemetalvname is defined
+        --cachemode {{item.0.cachemode | default('writethrough')}}
+        "/dev/{{item.0.vgname}}/{{item.0.cachelvname}}"
+  loop: "{{ gluster_infra_cache_vars | zip(checkpool_attrs.results) | list }}"
+  when: item.1.stdout.find('C') != 0
+  tags: debug
 
 # It is valid not to have cachemetalvname! Writing a separate task not to
 # complicate things.
-- name: Convert logical volume to a cache pool LV without cachemetalvname
-  command: >
-     lvconvert -y --type cache-pool
-        --poolmetadataspare n
-        --cachemode {{item.cachemode | default('writethrough')}}
-        "/dev/{{item.vgname}}/{{item.cachelvname}}"
-  with_items: "{{ gluster_infra_cache_vars }}"
-  when: item.cachemetalvname is not defined
+# - name: Convert logical volume to a cache pool LV without cachemetalvname
+#   command: >
+#      lvconvert -y --type cache-pool
+#         --poolmetadataspare n
+#         --cachemode {{item.cachemode | default('writethrough')}}
+#         "/dev/{{item.vgname}}/{{item.cachelvname}}"
+#   loop: "{{ gluster_infra_cache_vars }}"
+#   when: item.cachemetalvname is not defined
 
 # Run lvs -a -o +devices to see the cache settings
 - name: Convert an existing logical volume to a cache LV
   command: >
-     lvconvert -y --type cache --cachepool "/dev/{{item.vgname}}/{{item.cachelvname}}"
-     "/dev/{{item.vgname}}/{{item.cachethinpoolname}}"
-  with_items: "{{ gluster_infra_cache_vars }}"
+     lvconvert -y --type cache --cachepool "/dev/{{item.0.vgname}}/{{item.0.cachelvname}}"
+     "/dev/{{item.0.vgname}}/{{item.0.cachethinpoolname}}"
+#   with_items: "{{ gluster_infra_cache_vars }}"
+  loop: "{{ gluster_infra_cache_vars | zip(datapoolcache_attrs.results) | list }}"
+  loop_control:
+   index_var: index
+  #check if the LV exists and is not yet converted to a cache volume 
+  when: (datapool_attrs.results[index].stdout is not defined or datapool_attrs.results[index].stdout|length>0) and item.1.stdout.find(item.0.cachelvname) == -1
+  tags: debug

--- a/roles/backend_setup/tasks/cache_setup.yml
+++ b/roles/backend_setup/tasks/cache_setup.yml
@@ -37,20 +37,12 @@
   register: datapoolcache_attrs
   with_items: "{{ gluster_infra_cache_vars }}"  
 
-# - debug:
-#    var: datapool_attrs
-
-# - debug:
-#    var: item
-#   loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip((datapool_attrs is not none and datapool_attrs.results) or []) | list }}"
-
 - name: Change attributes of LV
   lvol:
      state: present
      vg: "{{ item.0.vgname }}"
      thinpool: "{{ item.0.cachetarget | default(item.0.cachethinpoolname) }}"
      opts: " --zero n "
-  #loop: "{{ gluster_infra_cache_vars|default([]) | zip(datapool_attrs.results|default([])) | list }}"
   loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((datapool_attrs is not none and datapool_attrs.results) or default([]))) | list }}"
   when: item.1.stdout is defined and item.1.stdout|length>0
 
@@ -63,6 +55,7 @@
      size: "{{ item.0.cachelvsize }}"
      pvs: "{{ item.0.cachedisk | default('') }}"
      opts: "{{ item.0.opts | default('') }}"
+  #errors throw when trying to modify an existing cachepool attached to a LV   
   #Operation not permitted on hidden LV ans_vg/cache-ans_thinpool2.
   #Sorry, no shrinking of cache-ans_thinpool3 without force=yes.
   when: item.1.stdout.find('C') != 0
@@ -88,7 +81,6 @@
   loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((checkpoolmeta_attrs is not none and checkpoolmeta_attrs.results) or default([])))| list }}"
   when: item.1.stdout is not defined or item.1.stdout.find('e') != 0
 
-# - meta: end_play 
 
 #Command on LV ans_vg/cache-ans_thinpool2 does not accept LV type cachepool
 - name: Convert logical volume to a cache pool LV

--- a/roles/backend_setup/tasks/cache_setup.yml
+++ b/roles/backend_setup/tasks/cache_setup.yml
@@ -37,11 +37,12 @@
   register: datapoolcache_attrs
   with_items: "{{ gluster_infra_cache_vars }}"  
 
-- debug: 
-   var: gluster_infra_cache_vars
+# - debug:
+#    var: datapool_attrs
 
-- debug: 
-   var: datapool_attrs
+# - debug:
+#    var: item
+#   loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip((datapool_attrs is not none and datapool_attrs.results) or []) | list }}"
 
 - name: Change attributes of LV
   lvol:
@@ -50,30 +51,44 @@
      thinpool: "{{ item.0.cachethinpoolname }}"
      opts: " --zero n "
   #loop: "{{ gluster_infra_cache_vars|default([]) | zip(datapool_attrs.results|default([])) | list }}"
-  loop: "{{ (gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([]) | zip(((datapool_attrs is not none and datapool_attrs.results) or default([]))) | list }}"
+  loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((datapool_attrs is not none and datapool_attrs.results) or default([]))) | list }}"
   when: item.1.stdout is defined and item.1.stdout|length>0
-
-
 
 - name: Create LV for cache
   lvol:
      state: present
+     shrink: false
      vg: "{{ item.0.vgname }}"
      lv: "{{ item.0.cachelvname }}"
      size: "{{ item.0.cachelvsize }}"
+     pvs: "{{ item.0.cachedisk | default('') }}"
+     opts: "{{ item.0.opts | default('') }}"
   #Operation not permitted on hidden LV ans_vg/cache-ans_thinpool2.
   #Sorry, no shrinking of cache-ans_thinpool3 without force=yes.
   when: item.1.stdout.find('C') != 0
-  loop: "{{ (gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([]) | zip(((checkpool_attrs is not none and checkpool_attrs.results) or default([]))) | list }}"
+  loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((checkpool_attrs is not none and checkpool_attrs.results) or default([]))) | list }}"
+
+- name: Make sure meta pv's exists in volume group
+  lvg:
+     state: present
+     vg: "{{ item.0.vgname }}"
+     pvs: "{{ item.0.meta_pvs }}"
+     pv_options: "--dataalignment 256K"
+  loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((checkpoolmeta_attrs is not none and checkpoolmeta_attrs.results) or default([])))| list }}"
+  when: item.0.meta_pvs is defined and (item.1.stdout is not defined or item.1.stdout.find('e') != 0)
 
 - name: Create metadata LV for cache
   lvol:
      state: present
      vg: "{{ item.0.vgname }}"
-     lv: "{{ item.0.cachemetalvname }}"
+     lv: "{{ item.0.cachemetalvname | default(item.0.cachelvname ~ '_meta') }}"
      size: "{{ item.0.cachemetalvsize }}"
-  loop: "{{ (gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([]) | zip(((checkpoolmeta_attrs is not none and checkpoolmeta_attrs.results) or default([])))| list }}"
-  when: item.0.cachemetalvname is defined and item.1.stdout.find('e') != 0
+     pvs: "{{ ((item.0.meta_pvs is defined and item.0.meta_pvs) or item.0.cachedisk) | default('') }}"
+     opts: "{{ ((item.0.meta_opts is defined and item.0.meta_opts) or item.0.opts) | default('') }}"
+  loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((checkpoolmeta_attrs is not none and checkpoolmeta_attrs.results) or default([])))| list }}"
+  when: item.1.stdout is not defined or item.1.stdout.find('e') != 0
+
+# - meta: end_play 
 
 #Command on LV ans_vg/cache-ans_thinpool2 does not accept LV type cachepool
 - name: Convert logical volume to a cache pool LV
@@ -85,7 +100,7 @@
         --poolmetadataspare n
         --cachemode {{item.0.cachemode | default('writethrough')}}
         "/dev/{{item.0.vgname}}/{{item.0.cachelvname}}"
-  loop: "{{ (gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([]) | zip(((checkpool_attrs is not none and checkpool_attrs.results) or default([]))) | list }}"
+  loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((checkpool_attrs is not none and checkpool_attrs.results) or default([]))) | list }}"
   when: item.1.stdout.find('C') != 0
 
 # Run lvs -a -o +devices to see the cache settings
@@ -93,7 +108,7 @@
   command: >
      lvconvert -y --type cache --cachepool "/dev/{{item.0.vgname}}/{{item.0.cachelvname}}"
      "/dev/{{item.0.vgname}}/{{item.0.cachethinpoolname}}"
-  loop: "{{ (gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([]) | zip(((datapoolcache_attrs is not none and datapoolcache_attrs.results) or default([]))) | list }}"
+  loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((datapoolcache_attrs is not none and datapoolcache_attrs.results) or default([]))) | list }}"
   loop_control:
    index_var: index
   #check if the LV exists and is not yet converted to a cache volume 

--- a/roles/backend_setup/tasks/cache_setup.yml
+++ b/roles/backend_setup/tasks/cache_setup.yml
@@ -37,14 +37,22 @@
   register: datapoolcache_attrs
   with_items: "{{ gluster_infra_cache_vars }}"  
 
+- debug: 
+   var: gluster_infra_cache_vars
+
+- debug: 
+   var: datapool_attrs
+
 - name: Change attributes of LV
   lvol:
      state: present
      vg: "{{ item.0.vgname }}"
      thinpool: "{{ item.0.cachethinpoolname }}"
      opts: " --zero n "
-  loop: "{{ gluster_infra_cache_vars | zip(datapool_attrs.results) | list }}"
+  #loop: "{{ gluster_infra_cache_vars|default([]) | zip(datapool_attrs.results|default([])) | list }}"
+  loop: "{{ (gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([]) | zip(((datapool_attrs is not none and datapool_attrs.results) or default([]))) | list }}"
   when: item.1.stdout is defined and item.1.stdout|length>0
+
 
 
 - name: Create LV for cache
@@ -56,7 +64,7 @@
   #Operation not permitted on hidden LV ans_vg/cache-ans_thinpool2.
   #Sorry, no shrinking of cache-ans_thinpool3 without force=yes.
   when: item.1.stdout.find('C') != 0
-  loop: "{{ gluster_infra_cache_vars | zip(checkpool_attrs.results) | list }}"
+  loop: "{{ (gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([]) | zip(((checkpool_attrs is not none and checkpool_attrs.results) or default([]))) | list }}"
 
 - name: Create metadata LV for cache
   lvol:
@@ -64,7 +72,7 @@
      vg: "{{ item.0.vgname }}"
      lv: "{{ item.0.cachemetalvname }}"
      size: "{{ item.0.cachemetalvsize }}"
-  loop: "{{ gluster_infra_cache_vars | zip(checkpoolmeta_attrs.results) | list }}"
+  loop: "{{ (gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([]) | zip(((checkpoolmeta_attrs is not none and checkpoolmeta_attrs.results) or default([])))| list }}"
   when: item.0.cachemetalvname is defined and item.1.stdout.find('e') != 0
 
 #Command on LV ans_vg/cache-ans_thinpool2 does not accept LV type cachepool
@@ -77,7 +85,7 @@
         --poolmetadataspare n
         --cachemode {{item.0.cachemode | default('writethrough')}}
         "/dev/{{item.0.vgname}}/{{item.0.cachelvname}}"
-  loop: "{{ gluster_infra_cache_vars | zip(checkpool_attrs.results) | list }}"
+  loop: "{{ (gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([]) | zip(((checkpool_attrs is not none and checkpool_attrs.results) or default([]))) | list }}"
   when: item.1.stdout.find('C') != 0
 
 # Run lvs -a -o +devices to see the cache settings
@@ -85,7 +93,7 @@
   command: >
      lvconvert -y --type cache --cachepool "/dev/{{item.0.vgname}}/{{item.0.cachelvname}}"
      "/dev/{{item.0.vgname}}/{{item.0.cachethinpoolname}}"
-  loop: "{{ gluster_infra_cache_vars | zip(datapoolcache_attrs.results) | list }}"
+  loop: "{{ (gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([]) | zip(((datapoolcache_attrs is not none and datapoolcache_attrs.results) or default([]))) | list }}"
   loop_control:
    index_var: index
   #check if the LV exists and is not yet converted to a cache volume 

--- a/roles/backend_setup/tasks/cache_setup.yml
+++ b/roles/backend_setup/tasks/cache_setup.yml
@@ -25,13 +25,13 @@
   with_items: "{{ gluster_infra_cache_vars }}"  
 
 - name: Check if logical data volume
-  shell: lvs -a --options 'lv_attr' --noheading {{item.vgname}}/{{item.cachethinpoolname}} | sed 's/^ *//;s/$//'
+  shell: lvs -a --options 'lv_attr' --noheading {{item.vgname}}/{{ item.cachetarget | default(item.cachethinpoolname) }} | sed 's/^ *//;s/$//'
   register: datapool_attrs
   with_items: "{{ gluster_infra_cache_vars }}"  
 
 - name: Check if logical volume exists and is backed by the cache pool
   shell: >
-      lvs -a --options 'data_lv,pool_lv' --separator "|" --noheadings  {{item.vgname}}/{{item.cachethinpoolname}} 2>/dev/null| 
+      lvs -a --options 'data_lv,pool_lv' --separator "|" --noheadings  {{item.vgname}}/{{item.cachetarget | default(item.cachethinpoolname)}} 2>/dev/null| 
          awk -F '|'   '{ gsub(/^\s*\[/,"",$1);gsub(/\]\|?$/,"",$1);if(length($2)>0){ print "echo "$2}else if(length($1)>0){ print "lvs -a --noheadings --options 'pool_lv' {{item.vgname}}/"$1}}'|
          bash|sed 's/^ *//;s/$//'
   register: datapoolcache_attrs
@@ -48,7 +48,7 @@
   lvol:
      state: present
      vg: "{{ item.0.vgname }}"
-     thinpool: "{{ item.0.cachethinpoolname }}"
+     thinpool: "{{ item.0.cachetarget | default(item.0.cachethinpoolname) }}"
      opts: " --zero n "
   #loop: "{{ gluster_infra_cache_vars|default([]) | zip(datapool_attrs.results|default([])) | list }}"
   loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((datapool_attrs is not none and datapool_attrs.results) or default([]))) | list }}"
@@ -107,7 +107,7 @@
 - name: Convert an existing logical volume to a cache LV
   command: >
      lvconvert -y --type cache --cachepool "/dev/{{item.0.vgname}}/{{item.0.cachelvname}}"
-     "/dev/{{item.0.vgname}}/{{item.0.cachethinpoolname}}"
+     "/dev/{{item.0.vgname}}/{{item.0.cachetarget | default(item.0.cachethinpoolname)}}"
   loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((datapoolcache_attrs is not none and datapoolcache_attrs.results) or default([]))) | list }}"
   loop_control:
    index_var: index

--- a/roles/backend_setup/tasks/cache_setup.yml
+++ b/roles/backend_setup/tasks/cache_setup.yml
@@ -18,59 +18,33 @@
   shell: "lvs --options 'lv_attr' -a --noheadings {{item.vgname}}/{{item.cachelvname}}| sed 's/^ *//;s/$//'"    
   register: checkpool_attrs
   with_items: "{{ gluster_infra_cache_vars }}"
-  tags: debug
 
 - name: Check if cachepool-metadata exists
   shell: "lvs --options 'lv_attr' -a --noheadings {{item.vgname}}/{{item.cachelvname}}_cmeta| sed 's/^ *//;s/$//'"    
   register: checkpoolmeta_attrs
   with_items: "{{ gluster_infra_cache_vars }}"  
-  tags: debug
 
 - name: Check if logical data volume
   shell: lvs -a --options 'lv_attr' --noheading {{item.vgname}}/{{item.cachethinpoolname}} | sed 's/^ *//;s/$//'
   register: datapool_attrs
   with_items: "{{ gluster_infra_cache_vars }}"  
-  tags: debug
 
 - name: Check if logical volume exists and is backed by the cache pool
-#   shell: >
-#       lvs -a --options 'data_lv' --noheading {{item.vgname}}/{{item.cachethinpoolname}} 2>/dev/null | awk '{ gsub(/^\[/,"",$1);gsub(/\]$/,"",$1);if(length($1)>0){ print "{{item.vgname}}/"$1}}' |
-#       xargs -r lvs -a --noheadings --options 'pool_lv'| sed 's/^ *//;s/$//'
   shell: >
       lvs -a --options 'data_lv,pool_lv' --separator "|" --noheadings  {{item.vgname}}/{{item.cachethinpoolname}} 2>/dev/null| 
          awk -F '|'   '{ gsub(/^\s*\[/,"",$1);gsub(/\]\|?$/,"",$1);if(length($2)>0){ print "echo "$2}else if(length($1)>0){ print "lvs -a --noheadings --options 'pool_lv' {{item.vgname}}/"$1}}'|
          bash|sed 's/^ *//;s/$//'
   register: datapoolcache_attrs
   with_items: "{{ gluster_infra_cache_vars }}"  
-  tags: debug  
-
-- debug: 
-   var: checkpool_attrs
-   verbosity: 1
-  tags: debug
-
-- debug: 
-   var: item.1.stdout.find(item.0.cachelvname)
-   verbosity: 1
-  loop: "{{ gluster_infra_cache_vars|zip(datapoolcache_attrs.results)|list }}"
-  tags: debug
-
-- debug: 
-   msg: "exec convert {{ item.0.cachelvname }} - {{ item.1.stdout }} - {{ item.1.stdout.find(item.0.cachelvname) }} = {{ index }}= {{datapool_attrs.results[index]}}"
-   verbosity: 0
-  loop: "{{ gluster_infra_cache_vars|zip(datapoolcache_attrs.results)|list }}"
-  loop_control:
-   index_var: index
-  #when: item.1.stdout.find(item.0.cachelvname) == -1
-  tags: debug
 
 - name: Change attributes of LV
   lvol:
      state: present
-     vg: "{{ item.vgname }}"
-     thinpool: "{{ item.cachethinpoolname }}"
+     vg: "{{ item.0.vgname }}"
+     thinpool: "{{ item.0.cachethinpoolname }}"
      opts: " --zero n "
-  with_items: "{{ gluster_infra_cache_vars }}"
+  loop: "{{ gluster_infra_cache_vars | zip(datapool_attrs.results) | list }}"
+  when: item.1.stdout is defined and item.1.stdout|length>0
 
 
 - name: Create LV for cache
@@ -79,12 +53,10 @@
      vg: "{{ item.0.vgname }}"
      lv: "{{ item.0.cachelvname }}"
      size: "{{ item.0.cachelvsize }}"
-  #with_items: "{{ gluster_infra_cache_vars }}"
   #Operation not permitted on hidden LV ans_vg/cache-ans_thinpool2.
   #Sorry, no shrinking of cache-ans_thinpool3 without force=yes.
   when: item.1.stdout.find('C') != 0
   loop: "{{ gluster_infra_cache_vars | zip(checkpool_attrs.results) | list }}"
-  tags: debug
 
 - name: Create metadata LV for cache
   lvol:
@@ -92,10 +64,8 @@
      vg: "{{ item.0.vgname }}"
      lv: "{{ item.0.cachemetalvname }}"
      size: "{{ item.0.cachemetalvsize }}"
-  #with_items: "{{ gluster_infra_cache_vars }}"
   loop: "{{ gluster_infra_cache_vars | zip(checkpoolmeta_attrs.results) | list }}"
   when: item.0.cachemetalvname is defined and item.1.stdout.find('e') != 0
-  tags: debug
 
 #Command on LV ans_vg/cache-ans_thinpool2 does not accept LV type cachepool
 - name: Convert logical volume to a cache pool LV
@@ -109,28 +79,15 @@
         "/dev/{{item.0.vgname}}/{{item.0.cachelvname}}"
   loop: "{{ gluster_infra_cache_vars | zip(checkpool_attrs.results) | list }}"
   when: item.1.stdout.find('C') != 0
-  tags: debug
-
-# It is valid not to have cachemetalvname! Writing a separate task not to
-# complicate things.
-# - name: Convert logical volume to a cache pool LV without cachemetalvname
-#   command: >
-#      lvconvert -y --type cache-pool
-#         --poolmetadataspare n
-#         --cachemode {{item.cachemode | default('writethrough')}}
-#         "/dev/{{item.vgname}}/{{item.cachelvname}}"
-#   loop: "{{ gluster_infra_cache_vars }}"
-#   when: item.cachemetalvname is not defined
 
 # Run lvs -a -o +devices to see the cache settings
 - name: Convert an existing logical volume to a cache LV
   command: >
      lvconvert -y --type cache --cachepool "/dev/{{item.0.vgname}}/{{item.0.cachelvname}}"
      "/dev/{{item.0.vgname}}/{{item.0.cachethinpoolname}}"
-#   with_items: "{{ gluster_infra_cache_vars }}"
   loop: "{{ gluster_infra_cache_vars | zip(datapoolcache_attrs.results) | list }}"
   loop_control:
    index_var: index
   #check if the LV exists and is not yet converted to a cache volume 
-  when: (datapool_attrs.results[index].stdout is not defined or datapool_attrs.results[index].stdout|length>0) and item.1.stdout.find(item.0.cachelvname) == -1
-  tags: debug
+  when: datapool_attrs.results[index].stdout is defined and datapool_attrs.results[index].stdout|length>0 and item.1.stdout.find(item.0.cachelvname) == -1
+

--- a/roles/backend_setup/tasks/fscreate.yml
+++ b/roles/backend_setup/tasks/fscreate.yml
@@ -16,6 +16,18 @@
       gluster_infra_disktype == 'RAID10' or
       gluster_infra_disktype == 'RAID5'
 
+- name: Check if thin block devices exists
+  shell: >
+   {%if (item.pvs is defined) %}
+   {% for pvsname in item.pvs.split(",")  %}
+   test -b {{ pvsname }} && echo "1" || echo  "0";
+   {% endfor %}
+   {% else %}
+   echo "1"
+   {% endif %}
+  register: lvt_device_exists
+  with_items: "{{ gluster_infra_lv_logicalvols }}"
+  when: item is not none
 
 # We support only XFS. Filesysem options sw, su are specific to XFS
 - name: Create filesystem on thin logical vols
@@ -25,7 +37,25 @@
      opts: "{{ fs_options }} {{ raid_options | default('') }}"
      force: "{{ gluster_infra_fs_force | default('no') }}"
   with_items: "{{ (gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols) or [] }}"
-  when: gluster_infra_lv_logicalvols is defined and (item.skipfs is not defined or not item.skipfs)
+  loop_control:
+   index_var: index
+  when: >
+    gluster_infra_lv_logicalvols is defined and (item.skipfs is not defined or not item.skipfs)
+    and lvt_device_exists.results[index].stdout_lines is defined and "0" not in lvt_device_exists.results[index].stdout_lines
+
+
+- name: Check if thick block devices exists
+  shell: >
+   {%if (item.pvs is defined) %}
+   {% for pvsname in item.pvs.split(",")  %}
+   test -b {{ pvsname }} && echo "1" || echo  "0";
+   {% endfor %}
+   {% else %}
+   echo "1"
+   {% endif %}
+  register: lv_device_exists
+  with_items: "{{ gluster_infra_thick_lvs }}"  
+  when: item is not none
 
 - name: Create filesystem on thick logical vols
   filesystem:
@@ -34,4 +64,8 @@
      opts: "{{ fs_options }} {{ raid_options | default('') }}"
      force: "{{ gluster_infra_fs_force | default('no') }}"
   with_items: "{{ (gluster_infra_thick_lvs is not none and gluster_infra_thick_lvs) or [] }}"
-  when: gluster_infra_thick_lvs is defined and (item.skipfs is not defined or not item.skipfs)
+  loop_control:
+   index_var: index
+  when: >
+    gluster_infra_thick_lvs is defined and (item.skipfs is not defined or not item.skipfs)
+    and lv_device_exists.results[index].stdout_lines is defined and "0" not in lv_device_exists.results[index].stdout_lines

--- a/roles/backend_setup/tasks/fscreate.yml
+++ b/roles/backend_setup/tasks/fscreate.yml
@@ -25,7 +25,7 @@
      opts: "{{ fs_options }} {{ raid_options | default('') }}"
      force: "{{ gluster_infra_fs_force | default('no') }}"
   with_items: "{{ gluster_infra_lv_logicalvols }}"
-  when: gluster_infra_lv_logicalvols is defined
+  when: gluster_infra_lv_logicalvols is defined and (item.skipfs is not defined or not item.skipfs)
 
 - name: Create filesystem on thick logical vols
   filesystem:
@@ -34,4 +34,4 @@
      opts: "{{ fs_options }} {{ raid_options | default('') }}"
      force: "{{ gluster_infra_fs_force | default('no') }}"
   with_items: "{{ gluster_infra_thick_lvs }}"
-  when: gluster_infra_thick_lvs is defined
+  when: gluster_infra_thick_lvs is defined and (item.skipfs is not defined or not item.skipfs)

--- a/roles/backend_setup/tasks/fscreate.yml
+++ b/roles/backend_setup/tasks/fscreate.yml
@@ -24,7 +24,7 @@
      dev: "/dev/{{ item.vgname }}/{{ item.lvname }}"
      opts: "{{ fs_options }} {{ raid_options | default('') }}"
      force: "{{ gluster_infra_fs_force | default('no') }}"
-  with_items: "{{ gluster_infra_lv_logicalvols }}"
+  with_items: "{{ (gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols) or [] }}"
   when: gluster_infra_lv_logicalvols is defined and (item.skipfs is not defined or not item.skipfs)
 
 - name: Create filesystem on thick logical vols
@@ -33,5 +33,5 @@
      dev: "/dev/{{ item.vgname }}/{{ item.lvname }}"
      opts: "{{ fs_options }} {{ raid_options | default('') }}"
      force: "{{ gluster_infra_fs_force | default('no') }}"
-  with_items: "{{ gluster_infra_thick_lvs }}"
+  with_items: "{{ (gluster_infra_thick_lvs is not none and gluster_infra_thick_lvs) or [] }}"
   when: gluster_infra_thick_lvs is defined and (item.skipfs is not defined or not item.skipfs)

--- a/roles/backend_setup/tasks/fstrim_service.yml
+++ b/roles/backend_setup/tasks/fstrim_service.yml
@@ -1,6 +1,4 @@
 ---
-- debug: var=fstrim_service
-
 
 - name: create fstrim-timer override directory
   file:

--- a/roles/backend_setup/tasks/fstrim_service.yml
+++ b/roles/backend_setup/tasks/fstrim_service.yml
@@ -1,0 +1,25 @@
+---
+- debug: var=fstrim_service
+
+
+- name: create fstrim-timer override directory
+  file:
+    path: /etc/systemd/system/fstrim.timer.d/
+    state: directory
+
+- name: schedule fstrim-timer
+  template:
+    src: fstrim.timer.j2
+    dest: /etc/systemd/system/fstrim.timer.d/override.conf
+
+- name: reload systemd
+  systemd:
+    daemon_reload: yes
+
+- name: manage fstrim-timer
+  systemd:
+    name: fstrim.timer
+    state: "{{ ((fstrim_service.enabled is defined and fstrim_service.enabled) and 'started') or 'stopped' }}"
+    enabled: "{{ ((fstrim_service.enabled is defined and fstrim_service.enabled) and true) or false }}"
+   
+

--- a/roles/backend_setup/tasks/lvm_config.yml
+++ b/roles/backend_setup/tasks/lvm_config.yml
@@ -1,6 +1,4 @@
 ---
-# - debug: var=gluster_infra_lvm
-
 
 #thin_pool_autoextend_threshold = 100
 #thin_pool_autoextend_percent = 20

--- a/roles/backend_setup/tasks/lvm_config.yml
+++ b/roles/backend_setup/tasks/lvm_config.yml
@@ -1,0 +1,21 @@
+---
+# - debug: var=gluster_infra_lvm
+
+
+#thin_pool_autoextend_threshold = 100
+#thin_pool_autoextend_percent = 20
+- name: Configure lvm thinpool extend threshold
+  lineinfile: 
+    path: /etc/lvm/lvm.conf
+    regex: "thin_pool_autoextend_threshold"
+    backrefs: true
+    line: thin_pool_autoextend_threshold = {{ gluster_infra_lvm.autoexpand_threshold }}
+  when: gluster_infra_lvm is defined and gluster_infra_lvm.autoexpand_threshold is defined
+
+- name: Configure lvm thinpool extend percentage
+  lineinfile: 
+    path: /etc/lvm/lvm.conf
+    regex: "thin_pool_autoextend_percent"
+    backrefs: true
+    line: thin_pool_autoextend_percent = {{ gluster_infra_lvm.autoexpand_percentage }}
+  when: gluster_infra_lvm is defined and gluster_infra_lvm.autoexpand_percentage is defined

--- a/roles/backend_setup/tasks/lvm_kernelparams.yml
+++ b/roles/backend_setup/tasks/lvm_kernelparams.yml
@@ -1,15 +1,5 @@
 ---
 
-- debug:
-    msg: >
-      {%- set output = [] -%}
-        {%- for lv in gluster_infra_thick_lvs -%}
-          {%- if lv.atboot -%}
-            {{- output.append( '' ~ lv.vgname ~ '/' ~ lv.lvname) -}}
-          {%- endif -%}
-        {%- endfor -%}
-      {{- 'rd.lvm.lv="' ~ (output | join(' ')) ~ '"' -}}
-  when: gluster_infra_thick_lvs is defined and gluster_infra_thick_lvs | selectattr("atboot") | list | length > 0
 
 - name: Add lvm thick volumes as kernel parameter
   lineinfile: 
@@ -20,12 +10,12 @@
     line:  >
       {%- set output = [] -%}
         {%- for lv in gluster_infra_thick_lvs -%}
-          {%- if lv.atboot -%}
+          {%- if lv.atboot is defined and lv.atboot -%}
             {{- output.append( 'rd.lvm.lv=' ~ lv.vgname ~ '/' ~ lv.lvname) -}}
           {%- endif -%}
         {%- endfor -%}
       {{- 'LVM_ADDITIONAL_DMS="' ~ (output | join(' ')) ~ '"' -}}
-  when: gluster_infra_thick_lvs is defined and gluster_infra_thick_lvs | selectattr("atboot") | list | length > 0
+  when: gluster_infra_thick_lvs is defined and gluster_infra_thick_lvs | selectattr("atboot","defined")| selectattr("atboot") | list | length > 0
   register: changed_lv_boot
 
 - name: check if grub kernel parameter contains the LVM_ADDITIONAL_DMS variable

--- a/roles/backend_setup/tasks/lvm_kernelparams.yml
+++ b/roles/backend_setup/tasks/lvm_kernelparams.yml
@@ -1,0 +1,58 @@
+---
+
+- debug:
+    msg: >
+      {%- set output = [] -%}
+        {%- for lv in gluster_infra_thick_lvs -%}
+          {%- if lv.atboot -%}
+            {{- output.append( '' ~ lv.vgname ~ '/' ~ lv.lvname) -}}
+          {%- endif -%}
+        {%- endfor -%}
+      {{- 'rd.lvm.lv="' ~ (output | join(' ')) ~ '"' -}}
+  when: gluster_infra_thick_lvs is defined and gluster_infra_thick_lvs | selectattr("atboot") | list | length > 0
+
+- name: Add lvm thick volumes as kernel parameter
+  lineinfile: 
+    path: /etc/default/grub
+    regex: "^LVM_ADDITIONAL_DMS"
+    insertbefore: BOF
+    firstmatch: true
+    line:  >
+      {%- set output = [] -%}
+        {%- for lv in gluster_infra_thick_lvs -%}
+          {%- if lv.atboot -%}
+            {{- output.append( 'rd.lvm.lv=' ~ lv.vgname ~ '/' ~ lv.lvname) -}}
+          {%- endif -%}
+        {%- endfor -%}
+      {{- 'LVM_ADDITIONAL_DMS="' ~ (output | join(' ')) ~ '"' -}}
+  when: gluster_infra_thick_lvs is defined and gluster_infra_thick_lvs | selectattr("atboot") | list | length > 0
+  register: changed_lv_boot
+
+- name: check if grub kernel parameter contains the LVM_ADDITIONAL_DMS variable
+  shell: "grep -E 'GRUB_CMDLINE_LINUX=.*?\\$LVM_ADDITIONAL_DMS.*?' /etc/default/grub"
+  register: has_grub_var
+  failed_when: false
+  
+- name: add lvm volumes to grub kernel parameter line  
+  lineinfile:
+   path: /etc/default/grub
+   regex: 'GRUB_CMDLINE_LINUX="(.*)"'
+   line: 'GRUB_CMDLINE_LINUX="\1 $LVM_ADDITIONAL_DMS"'   
+   backrefs: yes
+  when: has_grub_var.rc != 0
+  register: changed_grub_cmd_line
+
+- stat: path=/boot/efi/EFI/centos/grub.cfg
+  register: grub_conf
+
+- stat: path=/sys/firmware/efi
+  register: firm_efi
+
+
+- name: "rebuild efi boot"
+  shell: grub2-mkconfig -o /boot/efi/EFI/centos/grub.cfg
+  when: (changed_grub_cmd_line.changed or changed_lv_boot.changed) and firm_efi.stat.exists and grub_conf.stat.exists
+
+- name: "rebuild bios boot"
+  shell: grub2-mkconfig -o /boot/grub2/grub.cfg
+  when: (changed_grub_cmd_line.changed or changed_lv_boot.changed) and firm_efi.stat.exists==false and grub_conf.stat.exists==false

--- a/roles/backend_setup/tasks/main-lvm.yml
+++ b/roles/backend_setup/tasks/main-lvm.yml
@@ -1,0 +1,35 @@
+---
+
+- name: Create a volume group
+  import_tasks: vg_create.yml
+  when: gluster_infra_volume_groups is defined
+  tags:
+    - vgcreate
+
+# If a thick volume is requested for the same vg
+- name: Create a thick logical volume
+  import_tasks: thick_lv_create.yml
+  when: gluster_infra_thick_lvs is defined
+  tags:
+    - thickvol
+
+# Create a thinpool for the given volume group
+- name: Create thin pool
+  import_tasks: thin_pool_create.yml
+  when: gluster_infra_thinpools is defined
+  tags:
+    - thinpool
+
+# Create a thin volume
+- name: Create thin logical volume
+  import_tasks: thin_volume_create.yml
+  when: gluster_infra_lv_logicalvols is defined
+  tags:
+    - thinvol
+
+# Setup cache on the given SSD
+- name: Setup cache
+  import_tasks: cache_setup.yml
+  when: gluster_infra_cache_vars is defined and gluster_infra_cache_vars is not none
+  tags:
+    - cachesetup

--- a/roles/backend_setup/tasks/main-lvm.yml
+++ b/roles/backend_setup/tasks/main-lvm.yml
@@ -25,7 +25,7 @@
   import_tasks: thin_volume_create.yml
   when: gluster_infra_lv_logicalvols is defined
   tags:
-    - thinvol
+    - thinvol    
 
 # Setup cache on the given SSD
 - name: Setup cache
@@ -33,3 +33,4 @@
   when: gluster_infra_cache_vars is defined and gluster_infra_cache_vars is not none
   tags:
     - cachesetup
+

--- a/roles/backend_setup/tasks/main.yml
+++ b/roles/backend_setup/tasks/main.yml
@@ -88,7 +88,7 @@
 # set kernel boot params for lvm volumes
 - name: Configure lvm kernel parameters
   import_tasks: lvm_kernelparams.yml
-  when: gluster_infra_thick_lvs is defined and gluster_infra_thick_lvs | selectattr("atboot") | list | length > 0
+  when: gluster_infra_thick_lvs is defined and gluster_infra_thick_lvs | selectattr("atboot","defined")| selectattr("atboot") | list | length > 0
   tags:
     - lvmkernelparams
 

--- a/roles/backend_setup/tasks/main.yml
+++ b/roles/backend_setup/tasks/main.yml
@@ -38,8 +38,10 @@
   set_fact:
      vdo_devs: "{{ vdo_devs|default([]) + [ item.vgname ] }}"
   with_items: "{{ gluster_infra_volume_groups | default([]) }}"
-  when: item.pvname is search("/dev/mapper/")
+  when: item.pvname is defined and item.pvname is search("/dev/mapper/")
 
+
+#phase #1
 - name: Create a vdo disk
   import_tasks: vdo_create.yml
   when: gluster_infra_vdo is defined
@@ -48,6 +50,17 @@
 
 - name: "Execute phase #1 of LVM"
   import_tasks: main-lvm.yml
+
+#phase #2
+- name: "Create a vdo disk after LVM for phase #2"
+  import_tasks: vdo_create.yml
+  when: gluster_infra_vdo is defined and gluster_phase2_has_missing_devices is defined and gluster_phase2_has_missing_devices
+  tags:
+    - vdocreate
+
+- name: "Execute phase #2 of LVM"
+  import_tasks: main-lvm.yml
+  when: gluster_phase2_has_missing_devices is defined and gluster_phase2_has_missing_devices
 
 
 # Create a filesystem on the disks.

--- a/roles/backend_setup/tasks/main.yml
+++ b/roles/backend_setup/tasks/main.yml
@@ -84,3 +84,10 @@
   when: gluster_infra_mount_devices is defined and gluster_infra_mount_devices is not none
   tags:
     - mount
+
+# set kernel boot params for lvm volumes
+- name: Configure lvm kernel parameters
+  import_tasks: lvm_kernelparams.yml
+  when: gluster_infra_thick_lvs is defined and gluster_infra_thick_lvs | selectattr("atboot") | list | length > 0
+  tags:
+    - lvmkernelparams

--- a/roles/backend_setup/tasks/main.yml
+++ b/roles/backend_setup/tasks/main.yml
@@ -40,6 +40,13 @@
   with_items: "{{ gluster_infra_volume_groups | default([]) }}"
   when: item.pvname is defined and item.pvname is search("/dev/mapper/")
 
+# set lvm config
+- name: Configure LVM
+  import_tasks: lvm_config.yml
+  when: gluster_infra_lvm is defined
+  tags:
+    - lvmconfig
+
 
 #phase #1
 - name: Create a vdo disk

--- a/roles/backend_setup/tasks/main.yml
+++ b/roles/backend_setup/tasks/main.yml
@@ -46,39 +46,9 @@
   tags:
     - vdocreate
 
-- name: Create a volume group
-  import_tasks: vg_create.yml
-  when: gluster_infra_volume_groups is defined
-  tags:
-    - vgcreate
+- name: "Execute phase #1 of LVM"
+  import_tasks: main-lvm.yml
 
-# If a thick volume is requested for the same vg
-- name: Create a thick logical volume
-  import_tasks: thick_lv_create.yml
-  when: gluster_infra_thick_lvs is defined
-  tags:
-    - thickvol
-
-# Create a thinpool for the given volume group
-- name: Create thin pool
-  import_tasks: thin_pool_create.yml
-  when: gluster_infra_thinpools is defined
-  tags:
-    - thinpool
-
-# Create a thin volume
-- name: Create thin logical volume
-  import_tasks: thin_volume_create.yml
-  when: gluster_infra_lv_logicalvols is defined
-  tags:
-    - thinvol
-
-# Setup cache on the given SSD
-- name: Setup cache
-  import_tasks: cache_setup.yml
-  when: gluster_infra_cache_vars is defined
-  tags:
-    - cachesetup
 
 # Create a filesystem on the disks.
 - name: Create a filesystem on the disks
@@ -91,6 +61,6 @@
 # Mount the devices
 - name: Mount the devices
   import_tasks: mount.yml
-  when: gluster_infra_mount_devices is defined
+  when: gluster_infra_mount_devices is defined and gluster_infra_mount_devices is not none
   tags:
     - mount

--- a/roles/backend_setup/tasks/main.yml
+++ b/roles/backend_setup/tasks/main.yml
@@ -93,7 +93,7 @@
     - lvmkernelparams
 
 # set fstrim service 
-- name: Configure lvm kernel parameters
+- name: Configure fstrim service
   import_tasks: fstrim_service.yml
   when: fstrim_service is defined
   tags:

--- a/roles/backend_setup/tasks/main.yml
+++ b/roles/backend_setup/tasks/main.yml
@@ -37,7 +37,7 @@
 - name: Record VDO devices (if any)
   set_fact:
      vdo_devs: "{{ vdo_devs|default([]) + [ item.vgname ] }}"
-  with_items: "{{ gluster_infra_volume_groups }}"
+  with_items: "{{ gluster_infra_volume_groups | default([]) }}"
   when: item.pvname is search("/dev/mapper/")
 
 - name: Create a vdo disk

--- a/roles/backend_setup/tasks/main.yml
+++ b/roles/backend_setup/tasks/main.yml
@@ -91,3 +91,10 @@
   when: gluster_infra_thick_lvs is defined and gluster_infra_thick_lvs | selectattr("atboot") | list | length > 0
   tags:
     - lvmkernelparams
+
+# set fstrim service 
+- name: Configure lvm kernel parameters
+  import_tasks: fstrim_service.yml
+  when: fstrim_service is defined
+  tags:
+    - fstrim

--- a/roles/backend_setup/tasks/thick_lv_create.yml
+++ b/roles/backend_setup/tasks/thick_lv_create.yml
@@ -19,18 +19,6 @@
   loop: "{{ lv_device_exists.results }}"
   when: item.stdout_lines is defined and "0" in item.stdout_lines    
 
-# - debug:
-#    var: lv_device_exists
-
-# - debug:
-#    var: item
-#   with_items: "{{ gluster_infra_thick_lvs }}"
-#   loop_control:
-#    index_var: index
-#   when: lv_device_exists.results[index].stdout_lines is defined and "0" not in lv_device_exists.results[index].stdout_lines
-
-
-# - meta: end_play
 
 # Create a thick logical volume.
 - name: Create thick logical volume

--- a/roles/backend_setup/tasks/thick_lv_create.yml
+++ b/roles/backend_setup/tasks/thick_lv_create.yml
@@ -1,4 +1,37 @@
 ---
+
+- name: Check if thick-lv block devices exists
+  shell: >
+   {%if (item.pvs is defined) %}
+   {% for pvsname in item.pvs.split(",")  %}
+   test -b {{ pvsname }} && echo "1" || echo  "0";
+   {% endfor %}
+   {% else %}
+   echo "1"
+   {% endif %}
+  register: lv_device_exists
+  with_items: "{{ gluster_infra_thick_lvs }}"
+  when: item is not none
+
+- name: Record for missing devices for phase 2
+  set_fact:
+   gluster_phase2_has_missing_devices: true
+  loop: "{{ lv_device_exists.results }}"
+  when: item.stdout_lines is defined and "0" in item.stdout_lines    
+
+# - debug:
+#    var: lv_device_exists
+
+# - debug:
+#    var: item
+#   with_items: "{{ gluster_infra_thick_lvs }}"
+#   loop_control:
+#    index_var: index
+#   when: lv_device_exists.results[index].stdout_lines is defined and "0" not in lv_device_exists.results[index].stdout_lines
+
+
+# - meta: end_play
+
 # Create a thick logical volume.
 - name: Create thick logical volume
   lvol:
@@ -6,4 +39,9 @@
     vg: "{{ item.vgname }}"
     lv: "{{ item.lvname }}"
     size: "{{ item.size }}"
+    pvs: "{{ item.pvs | default() }}"
+    opts: "{{ item.opts | default() }}"
   with_items: "{{ gluster_infra_thick_lvs }}"
+  loop_control:
+   index_var: index
+  when: item is not none and lv_device_exists.results[index].stdout_lines is defined and "0" not in lv_device_exists.results[index].stdout_lines

--- a/roles/backend_setup/tasks/thin_pool_create.yml
+++ b/roles/backend_setup/tasks/thin_pool_create.yml
@@ -22,15 +22,140 @@
      lv_chunksize: '256K'
   when: gluster_infra_disktype == 'JBOD'
 
+- name: Check if thin-pool block devices exists
+  shell: >
+   {%if (item.pvs is defined) %}
+   {% for pvsname in item.pvs.split(",")  %}
+   test -b {{ pvsname }} && echo "1" || echo  "0";
+   {% endfor %}
+   {% else %}
+   echo "1"
+   {% endif %}
+  register: lvtp_device_exists
+  with_items: "{{ gluster_infra_thinpools }}"
+  when: item is not none
+
+- name: Record for missing devices for phase 2
+  set_fact:
+   gluster_phase2_has_missing_devices: true
+  loop: "{{ lvtp_device_exists.results }}"
+  when: item.stdout_lines is defined and "0" in item.stdout_lines  
+
+- name: Check if thinpool exists
+  shell: "lvs --options 'lv_attr' -a --noheadings {{item.vgname}}/{{item.thinpoolname}}| sed 's/^ *//;s/$//'"    
+  register: thinpool_attrs
+  with_items: "{{ gluster_infra_thinpools }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 
+   and item is defined and item is not none and item.thinpoolname is defined and item.thinpoolname is defined  and item.vgname is defined
+   and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
+   and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
+
+# - debug:
+#    var:  thinpool_attrs  
+
+# https://github.com/ansible/ansible/issues/13262
+# block of tasks, which is executed when there are valid pools and pool items are configured.
+# also it checks if the pool doesn't already exists
+- name: Create a LV thinpool-data
+  lvol:
+     state: present
+     shrink: false
+     vg: "{{ item.vgname }}"
+     lv: "{{ item.thinpoolname }}"
+     pvs: "{{ item.pvs | default() }}"     
+     size: "{{ item.thinpoolsize | default('100%FREE') }}"
+     opts: " 
+             {{ item.opts | default('') }} "
+  with_items: "{{ gluster_infra_thinpools }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 
+   and item is defined and item is not none and item.thinpoolname is defined and item.thinpoolname is defined  and item.vgname is defined   
+   and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
+   and (thinpool_attrs.results[index].stdout is not defined or thinpool_attrs.results[index].stdout.find("t") != 0)
+   and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
+
+- name: Make sure meta pv's exists in volume group
+  lvg:
+     state: present
+     vg: "{{ item.vgname }}"
+     pvs: "{{ item.meta_pvs }}"
+     pv_options: "--dataalignment 256K"
+  with_items: "{{ gluster_infra_thinpools }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 
+   and item is defined and item is not none and item.thinpoolname is defined and item.thinpoolname is defined  and item.vgname is defined   
+   and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
+   and (thinpool_attrs.results[index].stdout is not defined or thinpool_attrs.results[index].stdout.find("t") != 0)
+   and item.meta_pvs is defined
+
+- name: Create a LV thinpool-meta
+  lvol:
+     state: present
+     shrink: false
+     vg: "{{ item.vgname }}"
+     lv: "{{ item.thinpoolname }}_meta"
+     pvs: "{{ ((item.meta_pvs is defined and item.meta_pvs) or item.pvs) | default() }}"     
+     size: "{{ item.poolmetadatasize | default('4G') }}"
+     opts: " 
+             {{ ((item.meta_opts is defined and item.meta_opts) or item.opts) | default('') }} "
+  with_items: "{{ gluster_infra_thinpools }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 
+   and item is defined and item is not none and item.thinpoolname is defined and item.thinpoolname is defined  and item.vgname is defined   
+   and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
+   and (thinpool_attrs.results[index].stdout is not defined or thinpool_attrs.results[index].stdout.find("t") != 0)
+   and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
+
+
+
+# - meta: end_play   
+
+
+- name: Convert logical volume to a thin-pool
+  shell: >
+   lvconvert -y --type thin-pool {{item.vgname}}/{{item.thinpoolname}}
+   --poolmetadata {{ item.thinpoolname }}_meta
+   --chunksize {{ lv_chunksize }} 
+   --zero n
+  with_items: "{{ gluster_infra_thinpools }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 
+   and item is defined and item is not none and item.thinpoolname is defined and item.thinpoolname is defined  and item.vgname is defined   
+   and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
+   and (thinpool_attrs.results[index].stdout is not defined or thinpool_attrs.results[index].stdout.find("t") != 0)
+   and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
+
+
 - name: Create a LV thinpool
   lvol:
      state: present
      shrink: false
      vg: "{{ item.vgname }}"
+     pvs: "{{ item.pvs | default() }}"
      thinpool: "{{ item.thinpoolname }}"
      size: "{{ item.thinpoolsize | default('100%FREE') }}"
      opts: " --chunksize {{ lv_chunksize }}
              --poolmetadatasize {{ item.poolmetadatasize }}
-             --zero n"
+             --zero n
+             {{ item.opts | default('') }} "
   with_items: "{{ gluster_infra_thinpools }}"
-  when: gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 and item is defined and item is not none and item.thinpoolname is defined and item.thinpoolname is defined  and item.vgname is defined 
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 
+   and item is defined and item is not none and item.thinpoolname is defined and item.thinpoolname is defined  and item.vgname is defined   
+   and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
+   and ((item.opts is not defined or "raid" not in item.opts) and item.meta_pvs is not defined and item.meta_opts is not defined)
+#end-block
+# - meta: end_play   

--- a/roles/backend_setup/tasks/thin_pool_create.yml
+++ b/roles/backend_setup/tasks/thin_pool_create.yml
@@ -33,4 +33,4 @@
              --poolmetadatasize {{ item.poolmetadatasize }}
              --zero n"
   with_items: "{{ gluster_infra_thinpools }}"
-  when: gluster_infra_thinpools is defined
+  when: gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 and item is defined and item is not none and item.thinpoolname is defined and item.thinpoolname is defined  and item.vgname is defined 

--- a/roles/backend_setup/tasks/thin_pool_create.yml
+++ b/roles/backend_setup/tasks/thin_pool_create.yml
@@ -53,8 +53,6 @@
    and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
    and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
 
-# - debug:
-#    var:  thinpool_attrs  
 
 # https://github.com/ansible/ansible/issues/13262
 # block of tasks, which is executed when there are valid pools and pool items are configured.
@@ -117,9 +115,6 @@
 
 
 
-# - meta: end_play   
-
-
 - name: Convert logical volume to a thin-pool
   shell: >
    lvconvert -y --type thin-pool {{item.vgname}}/{{item.thinpoolname}}
@@ -158,4 +153,4 @@
    and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
    and ((item.opts is not defined or "raid" not in item.opts) and item.meta_pvs is not defined and item.meta_opts is not defined)
 #end-block
-# - meta: end_play   
+  

--- a/roles/backend_setup/tasks/thin_pool_create.yml
+++ b/roles/backend_setup/tasks/thin_pool_create.yml
@@ -100,7 +100,7 @@
      vg: "{{ item.vgname }}"
      lv: "{{ item.thinpoolname }}_meta"
      pvs: "{{ ((item.meta_pvs is defined and item.meta_pvs) or item.pvs) | default() }}"     
-     size: "{{ item.poolmetadatasize | default('4G') }}"
+     size: "{{ item.poolmetadatasize | default('16G') }}"
      opts: " 
              {{ ((item.meta_opts is defined and item.meta_opts) or item.opts) | default('') }} "
   with_items: "{{ gluster_infra_thinpools }}"

--- a/roles/backend_setup/tasks/thin_volume_create.yml
+++ b/roles/backend_setup/tasks/thin_volume_create.yml
@@ -2,6 +2,95 @@
 # Create a thin logical volume. A thinpool should already have been created by
 # now. There can be more than one thinvolume on a thinpool
 
+- name: Check if block devices exists
+  shell: >
+   {%if (item.pvs is defined) %}
+   {% for pvsname in item.pvs.split(",")  %}
+   test -b {{ pvsname }} && echo "1" || echo  "0";
+   {% endfor %}
+   {% else %}
+   echo "1"
+   {% endif %}
+  register: lvt_device_exists
+  with_items: "{{ gluster_infra_lv_logicalvols }}"
+
+# - debug:
+#    var: lvt_device_exists
+
+# - debug:
+#    var: gluster_infra_lv_logicalvols
+
+- name: Check if thinlv exists
+  shell: "lvs --options 'lv_attr' -a --noheadings {{item.vgname}}/{{item.lvname}}| sed 's/^ *//;s/$//'"    
+  register: thinlv_attrs
+  with_items: "{{ gluster_infra_lv_logicalvols }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none
+   and (item.opts is defined and "raid" in item.opts)
+   and lvt_device_exists.results[index].stdout_lines is defined and "0" not in lvt_device_exists.results[index].stdout_lines
+
+# - debug:
+#    var:  thinlv_attrs
+
+    
+
+- name: Create a LV thinlv-data
+  lvol:
+     state: present
+     shrink: false
+     vg: "{{ item.vgname }}"
+     lv: "{{ item.lvname }}"
+     pvs: "{{ item.pvs | default() }}"     
+     size: "{{ item.lvsize | default('100%FREE') }}"
+     opts: " 
+             {{ item.opts | default('') }} "
+  with_items: "{{ gluster_infra_lv_logicalvols }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none
+   and (item.opts is defined and "raid" in item.opts)
+   and lvt_device_exists.results[index].stdout_lines is defined and "0" not in lvt_device_exists.results[index].stdout_lines
+   and  (thinlv_attrs.results[index].stdout is not defined or thinlv_attrs.results[index].stdout.find("V") != 0)
+
+- name: Create a LV thinlv-meta
+  lvol:
+     state: present
+     shrink: false
+     vg: "{{ item.vgname }}"
+     lv: "{{ item.lvname }}_meta"
+     pvs: "{{ item.pvs | default() }}"
+     size: "{{ item.meta_size | default('4G') }}"
+     opts: " 
+             {{ item.opts | default('') }} "
+  with_items: "{{ gluster_infra_lv_logicalvols }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none   
+   and lvt_device_exists.results[index].stdout_lines is defined and "0" not in lvt_device_exists.results[index].stdout_lines
+   and (thinlv_attrs.results[index].stdout is not defined or thinlv_attrs.results[index].stdout.find("V") != 0)
+   and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined)
+
+
+
+- name: Convert logical volume to a thin-lv
+  shell: >
+   lvconvert -y --type thin {{item.vgname}}/{{item.lvname}}
+   --thinpool {{item.vgname}}/{{item.thinpool}}
+   --poolmetadata {{ item.lvname }}_meta
+   --zero n
+  with_items: "{{ gluster_infra_lv_logicalvols }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none   
+   and lvt_device_exists.results[index].stdout_lines is defined and "0" not in lvt_device_exists.results[index].stdout_lines
+   and  (thinlv_attrs.results[index].stdout is not defined or thinlv_attrs.results[index].stdout.find("V") != 0)
+   and ((item.opts is defined and "raid" in item.opts) and item.meta_pvs is not defined)
+
 - name: Create thin logical volume
   lvol:
      state: present
@@ -9,5 +98,18 @@
      lv: "{{ item.lvname }}"
      thinpool: "{{ item.thinpool }}"
      size: "{{ item.lvsize }}"
+     pvs: "{{ item.pvs | default() }}"
+     opts: >
+      {% if (item.meta_pvs is defined) %}
+      --poolmetadata {{ item.lvname }}_meta
+      {% endif %}
+      {{ item.opts | default() }}      
   with_items: "{{ gluster_infra_lv_logicalvols }}"
-  when:  gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none
+  loop_control:
+   index_var: index
+  when: >
+   gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none   
+   and lvt_device_exists.results[index].stdout_lines is defined and "0" not in lvt_device_exists.results[index].stdout_lines
+   and ((item.opts is not defined or "raid" not in item.opts) or item.meta_pvs is defined)
+
+- meta: end_play    

--- a/roles/backend_setup/tasks/thin_volume_create.yml
+++ b/roles/backend_setup/tasks/thin_volume_create.yml
@@ -76,7 +76,7 @@
      vg: "{{ item.vgname }}"
      lv: "{{ item.lvname }}_meta"
      pvs: "{{ ((item.meta_pvs is defined and item.meta_pvs) or item.pvs) | default() }}"
-     size: "{{ item.meta_size | default('4G') }}"
+     size: "{{ item.meta_size | default('16G') }}"
      opts: " 
              {{ ((item.meta_opts is defined and item.meta_opts) or item.opts) | default('') }} "
   with_items: "{{ gluster_infra_lv_logicalvols }}"

--- a/roles/backend_setup/tasks/thin_volume_create.yml
+++ b/roles/backend_setup/tasks/thin_volume_create.yml
@@ -15,11 +15,6 @@
   with_items: "{{ gluster_infra_lv_logicalvols }}"
   when: item is not none
 
-# - debug:
-#    var: lvt_device_exists
-
-# - debug:
-#    var: gluster_infra_lv_logicalvols
 
 - name: Record for missing devices for phase 2
   set_fact:
@@ -38,11 +33,7 @@
    gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none   
    and lvt_device_exists.results[index].stdout_lines is defined and "0" not in lvt_device_exists.results[index].stdout_lines
    and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
-
-# - debug:
-#    var:  thinlv_attrs
-
-    
+   
 
 - name: Create a LV thinlv-data
   lvol:
@@ -96,8 +87,6 @@
    and lvt_device_exists.results[index].stdout_lines is defined and "0" not in lvt_device_exists.results[index].stdout_lines
    and (thinlv_attrs.results[index].stdout is not defined or thinlv_attrs.results[index].stdout.find("V") != 0)
    and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
-
-# - meta: end_play 
 
 
 - name: Convert logical volume to a thin-lv

--- a/roles/backend_setup/tasks/thin_volume_create.yml
+++ b/roles/backend_setup/tasks/thin_volume_create.yml
@@ -2,7 +2,7 @@
 # Create a thin logical volume. A thinpool should already have been created by
 # now. There can be more than one thinvolume on a thinpool
 
-- name: Check if block devices exists
+- name: Check if thin-lv block devices exists
   shell: >
    {%if (item.pvs is defined) %}
    {% for pvsname in item.pvs.split(",")  %}
@@ -13,12 +13,20 @@
    {% endif %}
   register: lvt_device_exists
   with_items: "{{ gluster_infra_lv_logicalvols }}"
+  when: item is not none
 
 # - debug:
 #    var: lvt_device_exists
 
 # - debug:
 #    var: gluster_infra_lv_logicalvols
+
+- name: Record for missing devices for phase 2
+  set_fact:
+   gluster_phase2_has_missing_devices: true
+  loop: "{{ lvt_device_exists.results }}"
+  when: item.stdout_lines is defined and "0" in item.stdout_lines
+
 
 - name: Check if thinlv exists
   shell: "lvs --options 'lv_attr' -a --noheadings {{item.vgname}}/{{item.lvname}}| sed 's/^ *//;s/$//'"    
@@ -27,9 +35,9 @@
   loop_control:
    index_var: index
   when: > 
-   gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none
-   and (item.opts is defined and "raid" in item.opts)
+   gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none   
    and lvt_device_exists.results[index].stdout_lines is defined and "0" not in lvt_device_exists.results[index].stdout_lines
+   and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
 
 # - debug:
 #    var:  thinlv_attrs
@@ -51,20 +59,16 @@
    index_var: index
   when: > 
    gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none
-   and (item.opts is defined and "raid" in item.opts)
    and lvt_device_exists.results[index].stdout_lines is defined and "0" not in lvt_device_exists.results[index].stdout_lines
    and  (thinlv_attrs.results[index].stdout is not defined or thinlv_attrs.results[index].stdout.find("V") != 0)
+   and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
 
-- name: Create a LV thinlv-meta
-  lvol:
+- name: Make sure meta pv's exists in volume group
+  lvg:
      state: present
-     shrink: false
      vg: "{{ item.vgname }}"
-     lv: "{{ item.lvname }}_meta"
-     pvs: "{{ item.pvs | default() }}"
-     size: "{{ item.meta_size | default('4G') }}"
-     opts: " 
-             {{ item.opts | default('') }} "
+     pvs: "{{ item.meta_pvs }}"
+     pv_options: "--dataalignment 256K"
   with_items: "{{ gluster_infra_lv_logicalvols }}"
   loop_control:
    index_var: index
@@ -72,8 +76,28 @@
    gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none   
    and lvt_device_exists.results[index].stdout_lines is defined and "0" not in lvt_device_exists.results[index].stdout_lines
    and (thinlv_attrs.results[index].stdout is not defined or thinlv_attrs.results[index].stdout.find("V") != 0)
-   and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined)
+   and (item.meta_pvs is defined)
 
+- name: Create a LV thinlv-meta
+  lvol:
+     state: present
+     shrink: false
+     vg: "{{ item.vgname }}"
+     lv: "{{ item.lvname }}_meta"
+     pvs: "{{ ((item.meta_pvs is defined and item.meta_pvs) or item.pvs) | default() }}"
+     size: "{{ item.meta_size | default('4G') }}"
+     opts: " 
+             {{ ((item.meta_opts is defined and item.meta_opts) or item.opts) | default('') }} "
+  with_items: "{{ gluster_infra_lv_logicalvols }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none   
+   and lvt_device_exists.results[index].stdout_lines is defined and "0" not in lvt_device_exists.results[index].stdout_lines
+   and (thinlv_attrs.results[index].stdout is not defined or thinlv_attrs.results[index].stdout.find("V") != 0)
+   and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
+
+# - meta: end_play 
 
 
 - name: Convert logical volume to a thin-lv
@@ -89,8 +113,9 @@
    gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none   
    and lvt_device_exists.results[index].stdout_lines is defined and "0" not in lvt_device_exists.results[index].stdout_lines
    and  (thinlv_attrs.results[index].stdout is not defined or thinlv_attrs.results[index].stdout.find("V") != 0)
-   and ((item.opts is defined and "raid" in item.opts) and item.meta_pvs is not defined)
+   and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
 
+#this fails when the pool doesn't exist
 - name: Create thin logical volume
   lvol:
      state: present
@@ -100,9 +125,6 @@
      size: "{{ item.lvsize }}"
      pvs: "{{ item.pvs | default() }}"
      opts: >
-      {% if (item.meta_pvs is defined) %}
-      --poolmetadata {{ item.lvname }}_meta
-      {% endif %}
       {{ item.opts | default() }}      
   with_items: "{{ gluster_infra_lv_logicalvols }}"
   loop_control:
@@ -110,6 +132,6 @@
   when: >
    gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none   
    and lvt_device_exists.results[index].stdout_lines is defined and "0" not in lvt_device_exists.results[index].stdout_lines
-   and ((item.opts is not defined or "raid" not in item.opts) or item.meta_pvs is defined)
+   and ((item.opts is not defined or "raid" not in item.opts) and item.meta_pvs is not defined and item.meta_opts is not defined)
 
-- meta: end_play    
+   

--- a/roles/backend_setup/tasks/thin_volume_create.yml
+++ b/roles/backend_setup/tasks/thin_volume_create.yml
@@ -10,3 +10,4 @@
      thinpool: "{{ item.thinpool }}"
      size: "{{ item.lvsize }}"
   with_items: "{{ gluster_infra_lv_logicalvols }}"
+  when:  gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none

--- a/roles/backend_setup/tasks/vdo_create.yml
+++ b/roles/backend_setup/tasks/vdo_create.yml
@@ -43,7 +43,7 @@
     biothreads: "{{ item.biothreads | default('4') }}"
     cputhreads: "{{ item.cputhreads | default('2') }}"
     logicalthreads: "{{ item.logicalthreads | default('1') }}"
-    physicalthreads: "{{ item.physicalthreads | default('1') }}"  
+    physicalthreads: "{{ item.physicalthreads | default('1') }}"
   with_items: "{{ gluster_infra_vdo }}"
   loop_control:
    index_var: index

--- a/roles/backend_setup/tasks/vdo_create.yml
+++ b/roles/backend_setup/tasks/vdo_create.yml
@@ -28,4 +28,5 @@
     cputhreads: "{{ item.cputhreads | default('2') }}"
     logicalthreads: "{{ item.logicalthreads | default('1') }}"
     physicalthreads: "{{ item.physicalthreads | default('1') }}"
+  when: item.device is defined
   with_items: "{{ gluster_infra_vdo }}"

--- a/roles/backend_setup/tasks/vdo_create.yml
+++ b/roles/backend_setup/tasks/vdo_create.yml
@@ -1,7 +1,5 @@
 ---
 
-- debug:
-   msg: "do vdo!"
 
 # Start the vdo service
 - name: Enable and start vdo service
@@ -16,21 +14,6 @@
   with_items: "{{ gluster_infra_vdo }}"
   when: item.device is defined
   
-
-# - name: Update facts about vdo block devices
-#   set_fact: 
-#     gluster_infra_vdo: "{{ gluster_infra_vdo | combine(dm_fact, recursive=true) }}"
-#   vars:
-#     dm_fact: "{ 'dm_exists':'{{ vdo_device_exists.results[index].stdout }}' }"
-#   when: item.device is defined
-#   with_items: "{{ gluster_infra_vdo }}"
-#   loop_control:
-#    index_var: index
-  
-# - debug:
-#    var: gluster_infra_vdo
-# - debug:
-#     var: vdo_device_exists
 
 - name: Record for missing devices for phase 2
   set_fact:
@@ -67,14 +50,3 @@
   #when we have a device and it exists 
   when: item.device is defined and vdo_device_exists.results[index].stdout is defined and vdo_device_exists.results[index].stdout == "1"
 
-
-# - shell: "vdo status -n {{ item.name }}"
-#   register: vdo_status
-#   with_items: "{{ gluster_infra_vdo }}"
-#   loop_control:
-#    index_var: index
-#   when: item.device is defined and vdo_device_exists.results[index].stdout is defined and vdo_device_exists.results[index].stdout == "1"
-  
-  
-# - debug:
-#    var: vdo_status

--- a/roles/backend_setup/tasks/vdo_create.yml
+++ b/roles/backend_setup/tasks/vdo_create.yml
@@ -1,10 +1,43 @@
 ---
+
+- debug:
+   msg: "do vdo!"
+
 # Start the vdo service
 - name: Enable and start vdo service
   service:
     name: vdo
     state: started
     enabled: yes
+
+- name: Check if vdo block device exists
+  shell: test -b {{ item.device }} && echo "1" || echo  "0"
+  register: vdo_device_exists
+  with_items: "{{ gluster_infra_vdo }}"
+  when: item.device is defined
+  
+
+# - name: Update facts about vdo block devices
+#   set_fact: 
+#     gluster_infra_vdo: "{{ gluster_infra_vdo | combine(dm_fact, recursive=true) }}"
+#   vars:
+#     dm_fact: "{ 'dm_exists':'{{ vdo_device_exists.results[index].stdout }}' }"
+#   when: item.device is defined
+#   with_items: "{{ gluster_infra_vdo }}"
+#   loop_control:
+#    index_var: index
+  
+# - debug:
+#    var: gluster_infra_vdo
+# - debug:
+#     var: vdo_device_exists
+
+- name: Record for missing devices for phase 2
+  set_fact:
+   gluster_phase2_has_missing_devices: true
+  loop: "{{ vdo_device_exists.results }}"
+  when: item.stdout is defined and item.stdout == "0"
+
 
 - name: Create VDO with specified size
   vdo:
@@ -27,6 +60,21 @@
     biothreads: "{{ item.biothreads | default('4') }}"
     cputhreads: "{{ item.cputhreads | default('2') }}"
     logicalthreads: "{{ item.logicalthreads | default('1') }}"
-    physicalthreads: "{{ item.physicalthreads | default('1') }}"
-  when: item.device is defined
+    physicalthreads: "{{ item.physicalthreads | default('1') }}"  
   with_items: "{{ gluster_infra_vdo }}"
+  loop_control:
+   index_var: index
+  #when we have a device and it exists 
+  when: item.device is defined and vdo_device_exists.results[index].stdout is defined and vdo_device_exists.results[index].stdout == "1"
+
+
+# - shell: "vdo status -n {{ item.name }}"
+#   register: vdo_status
+#   with_items: "{{ gluster_infra_vdo }}"
+#   loop_control:
+#    index_var: index
+#   when: item.device is defined and vdo_device_exists.results[index].stdout is defined and vdo_device_exists.results[index].stdout == "1"
+  
+  
+# - debug:
+#    var: vdo_status

--- a/roles/backend_setup/tasks/vg_create.yml
+++ b/roles/backend_setup/tasks/vg_create.yml
@@ -41,6 +41,22 @@
      gluster_infra_disktype == 'RAID10' or
      gluster_infra_disktype == 'RAID5'
 
+- name: Check if vg block device exists
+  shell: test -b {{ item.pvname }} && echo "1" || echo  "0"
+  register: vg_device_exists
+  with_items: "{{ gluster_infra_volume_groups }}"
+  when: item.pvname is defined
+  
+- name: Record for missing devices for phase 2
+  set_fact:
+   gluster_phase2_has_missing_devices: true
+  loop: "{{ vg_device_exists.results }}"
+  when: item.stdout is defined and item.stdout == "0"
+
+
+# - debug:
+#    var: vg_device_exists
+
 # Tasks to create a volume group
 # The devices in `pvs' can be a regular device or a VDO device
 - name: Create volume groups
@@ -50,5 +66,9 @@
     pvs: "{{ item.pvname }}"
     pv_options: "--dataalignment {{ pv_dataalign }}"
     # pesize is 4m by default for JBODs
-    pesize: "{{ vg_pesize | default(4) }}"
+    pesize: "{{ vg_pesize | default(4) }}"  
   with_items: "{{ gluster_infra_volume_groups }}"
+  loop_control:
+   index_var: index
+  when: item.pvname is defined and vg_device_exists.results[index].stdout is defined and vg_device_exists.results[index].stdout == "1"
+

--- a/roles/backend_setup/tasks/vg_create.yml
+++ b/roles/backend_setup/tasks/vg_create.yml
@@ -63,7 +63,7 @@
     pvs: "{{ item.pvname }}"
     pv_options: "--dataalignment {{ pv_dataalign }}"
     # pesize is 4m by default for JBODs
-    pesize: "{{ vg_pesize | default(4) }}"  
+    pesize: "{{ vg_pesize | default(4) }}"
   with_items: "{{ gluster_infra_volume_groups }}"
   loop_control:
    index_var: index

--- a/roles/backend_setup/tasks/vg_create.yml
+++ b/roles/backend_setup/tasks/vg_create.yml
@@ -54,9 +54,6 @@
   when: item.stdout is defined and item.stdout == "0"
 
 
-# - debug:
-#    var: vg_device_exists
-
 # Tasks to create a volume group
 # The devices in `pvs' can be a regular device or a VDO device
 - name: Create volume groups

--- a/roles/backend_setup/templates/fstrim.timer.j2
+++ b/roles/backend_setup/templates/fstrim.timer.j2
@@ -1,0 +1,29 @@
+{% macro timeUnit(unit, max) -%}
+    {%- if unit is not defined or unit is none -%}
+    {{-  max | random -}}
+    {%- else -%}
+    {{- unit -}}
+    {%- endif -%}    
+{%- endmacro -%}
+
+[Timer]
+#AccuracySec=1s
+{% if fstrim_service.schedule is defined and fstrim_service.schedule is not none 
+and  fstrim_service.schedule.dow is not defined and fstrim_service.schedule.dow is not none 
+and  fstrim_service.schedule.hour is not defined and fstrim_service.schedule.hour is not none 
+and  fstrim_service.schedule.second is not defined and fstrim_service.schedule.second is not none 
+-%}
+{%- else -%}
+OnCalendar=
+OnCalendar={%- if fstrim_service.schedule.dow is not defined or fstrim_service.schedule.dow is none -%}
+{{- ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'] | random() -}}
+{%- else -%}
+{{- fstrim_service.schedule.dow -}}
+{%- endif -%}
+{{- ' *-*-* ' -}}
+{{- timeUnit(fstrim_service.schedule.hour, 24) -}}
+{{- ':' -}}
+{{- timeUnit(fstrim_service.schedule.minute, 60) -}}
+{{- ':' -}}
+{{- timeUnit(fstrim_service.schedule.second, 60) -}}
+{%- endif -%}


### PR DESCRIPTION
This PR aims to allow for LVM/VDO configurations to be configured using these roles. Also this should allow these roles to be executed multiple times without producing errors. For example when a cachedisk is setup, this can role could only ran once, after which it fails since the lvm volume is migrated to a hidden volume. This could be identified as an issue with the underlying lvm ansible module, which should be idempotent. But i can imagine this is quite a hard requirement, since the properties of the volume change.
One of the major changes in this PR is that the LVM tasks can be executed twice. 
This is to support setups where you want to have a DM chain as of; [PV]=>[VG]=>[LV]=>[VDO]=>[Thin LV]
Since the 2 are dependent on each other, in the first run the legs before the VDO needs to be created, and the second run the legs after the VDO. Of course a better solutions for this would to build a dependency graph or change the variable structure so they describe the desired hierarchy.
Currently this is achieved by unrolling these tasks in 2 phases. the second phase is only executed when in the first phase there were missing devices.

To summarize things;
- fixes serveral issues in the cache setup, for rerunning the tasks. Also i noticed the cachedisk wasn't passed along while creating the cachedata LV.
- Allow to pass most lvm ansible module params from the gluster_infra_* variables. advantages of this include: 
    - run the metadata LV on different physical devices and optionally in mirrored mode (as advised by lvm) 
    - have flexibility in how certain volumes or properties thereof are created
- tasks still aren't idempotent, but at least won't fail when executed more than once.
- added an option to configure the fstrim timer
- added an option to configure adding the lvm volumes as kernel parameter, this seemed need in case you want to have an VDO volume on top of a thick LV, which are placed in the same VG. For having the VDO in a separate VG doesn't didn't seem necessary. 

If you want to give it a quick spin, i've made this Vagrant gist; https://gist.github.com/olafbuitelaar/d2d24b07dbd377b62fb7d42d40a93046