### PR TITLE
Fix new ansible lvg module

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ gluster_infra_lv_logicalvols:
 * opts: Optional, Default empty, additional parameters being passed to the lvm module, which uses those in lvcreate
 * meta_pvs: Optional, Default empty, the physical devices the metadata volume should be placed on
 * meta_opts: Optional, Default empty, additional parameters to pass to lvcreate for creating the metadata volume
-* skipfs: Optional Boolean, Default no. When yes no XFS filesystem will be created on the LV
+* skipfs: Optional Boolean, Default no. When yes no XFS filesystem will be created on the 
+* shrink: Optional Boolean, Default yes. When no the lvol module will not try to shrink the LV
 
 -----------------------
 #### Thick LV variable
@@ -159,6 +160,7 @@ gluster_infra_thick_lvs:
 * opts: Optional, Default empty, additional parameters being passed to the lvm module, which uses those in lvcreate
 * skipfs: Optional Boolean, Default no. When yes no XFS filesystem will be created on the LV
 * atboot: Optional Boolean, Default no. When yes the parameter "rd.lvm.lv=DM" will be added to the kernel parameters in grub
+* shrink: Optional Boolean, Default yes. When no the lvol module will not try to shrink the LV
 
 ----------------------
 #### Thinpool variable

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ respective sub-roles directory.
 | gluster_infra_vdo || UNDEF | Mandatory argument if vdo has to be setup. Key/Value pairs have to be given. See examples for syntax. |
 | gluster_infra_disktype | JBOD / RAID6 / RAID10  | UNDEF   | Backend disk type. |
 | gluster_infra_diskcount || UNDEF | RAID diskcount, can be ignored if disktype is JBOD  |
-| gluster_infra_volume_groups  || UNDEF | Key/value pairs of vgname and pvname. pvname can be comma-separated values if more than a single pv is needed for a vg. See below for syntax. This variable is mandatory when PV's are not specified in the LV's |
+| gluster_infra_volume_groups  || UNDEF | Key/value pairs of vgname and pvname. pvname can be comma-separated values if more than a single pv is needed for a vg. See below for syntax. This variable is mandatory when PVs are not specified in the LVs |
 | gluster_infra_stripe_unit_size || UNDEF| Stripe unit size (KiB). *DO NOT* including trailing 'k' or 'K'  |
 | gluster_infra_lv_poolmetadatasize || 16G | Metadata size for LV, recommended value 16G is used by default. That value can be overridden by setting the variable. Include the unit [G\|M\|K] |
 | gluster_infra_thinpools || | Thinpool data. This is a dictionary with keys vgname, thinpoolname, thinpoolsize, and poolmetadatasize. See below for syntax and example. |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ respective sub-roles directory.
 | gluster_infra_vdo || UNDEF | Mandatory argument if vdo has to be setup. Key/Value pairs have to be given. See examples for syntax. |
 | gluster_infra_disktype | JBOD / RAID6 / RAID10  | UNDEF   | Backend disk type. |
 | gluster_infra_diskcount || UNDEF | RAID diskcount, can be ignored if disktype is JBOD  |
-| gluster_infra_volume_groups  || | Mandatory variable, key/value pairs of vgname and pvname. pvname can be comma-separated values if more than a single pv is needed for a vg. See below for syntax. |
+| gluster_infra_volume_groups  || UNDEF | Key/value pairs of vgname and pvname. pvname can be comma-separated values if more than a single pv is needed for a vg. See below for syntax. This variable is mandatory when PV's are not specified in the LV's |
 | gluster_infra_stripe_unit_size || UNDEF| Stripe unit size (KiB). *DO NOT* including trailing 'k' or 'K'  |
 | gluster_infra_lv_poolmetadatasize || 16G | Metadata size for LV, recommended value 16G is used by default. That value can be overridden by setting the variable. Include the unit [G\|M\|K] |
 | gluster_infra_thinpools || | Thinpool data. This is a dictionary with keys vgname, thinpoolname, thinpoolsize, and poolmetadatasize. See below for syntax and example. |
@@ -194,7 +194,7 @@ gluster_infra_thinpools:
 
 ```
 vgname - The vg which will be extended to setup cache.
-cachedisk - The SSD disk which will be used to setup cache. Complete path, for eg: /dev/sdd
+cachedisk - Comma seperated list of asbsolute-paths of block devices (e.g. SSD, NVMe; /dev/ssd) to use as caching medium.
 cachethinpoolname - (deprecated, see: cachetarget) The existing thinpool on the volume group mentioned above.
 cachetarget - The target thinpool or thick LV that should be cached
 cachelvname - Logical volume name for setting up cache, an lv with this name is created.

--- a/roles/backend_setup/tasks/cache_setup.yml
+++ b/roles/backend_setup/tasks/cache_setup.yml
@@ -7,80 +7,79 @@
 # caching)
 
 - name: Check if cachepool exists
-  shell: "lvs --options 'lv_attr' -a --noheadings {{item.vgname}}/{{item.cachelvname}}| sed 's/^ *//;s/$//'"    
+  shell: "lvs --options 'lv_attr' -a --noheadings {{item.vgname}}/{{item.cachelvname}}| sed 's/^ *//;s/$//'"
   register: checkpool_attrs
   with_items: "{{ gluster_infra_cache_vars }}"
 
 - name: Check if cachepool-metadata exists
-  shell: "lvs --options 'lv_attr' -a --noheadings {{item.vgname}}/{{item.cachelvname}}_cmeta| sed 's/^ *//;s/$//'"    
+  shell: "lvs --options 'lv_attr' -a --noheadings {{item.vgname}}/{{item.cachelvname}}_cmeta| sed 's/^ *//;s/$//'"
   register: checkpoolmeta_attrs
-  with_items: "{{ gluster_infra_cache_vars }}"  
+  with_items: "{{ gluster_infra_cache_vars }}"
 
 - name: Check if logical data volume
   shell: lvs -a --options 'lv_attr' --noheading {{item.vgname}}/{{ item.cachetarget | default(item.cachethinpoolname) }} | sed 's/^ *//;s/$//'
   register: datapool_attrs
-  with_items: "{{ gluster_infra_cache_vars }}"  
+  with_items: "{{ gluster_infra_cache_vars }}"
 
 - name: Check if logical volume exists and is backed by the cache pool
   shell: >
-      lvs -a --options 'data_lv,pool_lv' --separator "|" --noheadings  {{item.vgname}}/{{item.cachetarget | default(item.cachethinpoolname)}} 2>/dev/null| 
-         awk -F '|'   '{ gsub(/^\s*\[/,"",$1);gsub(/\]\|?$/,"",$1);if(length($2)>0){ print "echo "$2}else if(length($1)>0){ print "lvs -a --noheadings --options 'pool_lv' {{item.vgname}}/"$1}}'|
-         bash|sed 's/^ *//;s/$//'
+    lvs -a --options 'pool_lv' --noheadings {{ item.vgname }}/{{ item.cachetarget | default(item.cachethinpoolname) }} | grep cache
   register: datapoolcache_attrs
-  with_items: "{{ gluster_infra_cache_vars }}"  
+  failed_when: false
+  with_items: "{{ gluster_infra_cache_vars }}"
 
 - name: Change attributes of LV
   lvol:
-     state: present
-     vg: "{{ item.0.vgname }}"
-     thinpool: "{{ item.0.cachetarget | default(item.0.cachethinpoolname) }}"
-     opts: " --zero n "
+    state: present
+    vg: "{{ item.0.vgname }}"
+    thinpool: "{{ item.0.cachetarget | default(item.0.cachethinpoolname) }}"
+    opts: " --zero n "
   loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((datapool_attrs is not none and datapool_attrs.results) or default([]))) | list }}"
   when: item.1.stdout is defined and item.1.stdout|length>0
 
 - include_tasks: get_vg_groupings.yml
-  vars: 
-   volume_groups: >-
+  vars:
+    volume_groups: >-
       {%- set output=[] -%}
       {%- for cnf in gluster_infra_cache_vars -%}
-      {%- if cnf is defined and cnf is not none and cnf.vgname is defined            
+      {%- if cnf is defined and cnf is not none and cnf.vgname is defined
             and (cnf.cachedisk is defined or cnf.meta_pvs is defined)
       -%}
       {{- output.append({"vgname": cnf.vgname, "pvname": (cnf.cachedisk|default('') ~ ',' ~ (cnf.meta_pvs|default(''))).split(',') | select | list | unique | join(',')}) -}}
       {%- endif -%}
       {%- endfor -%}
       {{- output | to_json -}}
-  when: gluster_infra_cache_vars is defined and gluster_infra_cache_vars is not none and gluster_infra_cache_vars|length >0    
+  when: gluster_infra_cache_vars is defined and gluster_infra_cache_vars is not none and gluster_infra_cache_vars|length >0
 
 - name: Make sure meta and cache pv's exists in volume group
   register: gluster_changed_vgs
   lvg:
-     state: present
-     vg: "{{ (item.value | first).vgname }}"
-     pvs: "{{ item.value | json_query('[].pvname') | unique | join(',') }}"
-     pv_options: "--dataalignment 256K"  
+    state: present
+    vg: "{{ (item.value | first).vgname }}"
+    pvs: "{{ item.value | json_query('[].pvname') | unique | join(',') }}"
+    pv_options: "--dataalignment 256K"
   loop: "{{ gluster_volumes_by_groupname | dict2items }}"
   loop_control:
-   index_var: index
-  when: > 
-   gluster_volumes_by_groupname is defined and gluster_volumes_by_groupname is not none and gluster_volumes_by_groupname|length >0 
-   and item.value|length>0
+    index_var: index
+  when: >
+    gluster_volumes_by_groupname is defined and gluster_volumes_by_groupname is not none and gluster_volumes_by_groupname|length >0
+    and item.value|length>0
 
 - name: update LVM fact's
-  setup: 
-   filter: 'ansible_lvm'
-  when: gluster_changed_vgs.changed 
+  setup:
+    filter: 'ansible_lvm'
+  when: gluster_changed_vgs.changed
 
 - name: Create LV for cache
   lvol:
-     state: present
-     shrink: false
-     vg: "{{ item.0.vgname }}"
-     lv: "{{ item.0.cachelvname }}"
-     size: "{{ item.0.cachelvsize }}"
-     pvs: "{{ item.0.cachedisk | default('') }}"
-     opts: "{{ item.0.opts | default('') }}"
-  #errors throw when trying to modify an existing cachepool attached to a LV   
+    state: present
+    shrink: false
+    vg: "{{ item.0.vgname }}"
+    lv: "{{ item.0.cachelvname }}"
+    size: "{{ item.0.cachelvsize }}"
+    pvs: "{{ item.0.cachedisk | default('') }}"
+    opts: "{{ item.0.opts | default('') }}"
+  #errors throw when trying to modify an existing cachepool attached to a LV
   #Operation not permitted on hidden LV ans_vg/cache-ans_thinpool2.
   #Sorry, no shrinking of cache-ans_thinpool3 without force=yes.
   when: item.1.stdout.find('C') != 0
@@ -88,37 +87,38 @@
 
 - name: Create metadata LV for cache
   lvol:
-     state: present
-     vg: "{{ item.0.vgname }}"
-     lv: "{{ item.0.cachemetalvname | default(item.0.cachelvname ~ '_meta') }}"
-     size: "{{ item.0.cachemetalvsize }}"
-     pvs: "{{ ((item.0.meta_pvs is defined and item.0.meta_pvs) or item.0.cachedisk) | default('') }}"
-     opts: "{{ ((item.0.meta_opts is defined and item.0.meta_opts) or item.0.opts) | default('') }}"
+    state: present
+    vg: "{{ item.0.vgname }}"
+    lv: "{{ item.0.cachemetalvname | default(item.0.cachelvname ~ '_meta') }}"
+    size: "{{ item.0.cachemetalvsize }}"
+    pvs: "{{ ((item.0.meta_pvs is defined and item.0.meta_pvs) or item.0.cachedisk) | default('') }}"
+    opts: "{{ ((item.0.meta_opts is defined and item.0.meta_opts) or item.0.opts) | default('') }}"
   loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((checkpoolmeta_attrs is not none and checkpoolmeta_attrs.results) or default([])))| list }}"
   when: item.1.stdout is not defined or item.1.stdout.find('e') != 0
-
 
 #Command on LV ans_vg/cache-ans_thinpool2 does not accept LV type cachepool
 - name: Convert logical volume to a cache pool LV
   command: >
-     lvconvert -y --type cache-pool 
-        {% if item.0.cachemetalvname is defined %} 
-         --poolmetadata {{ item.0.cachemetalvname }} 
-        {% endif %}
-        --poolmetadataspare n
-        --cachemode {{item.0.cachemode | default('writethrough')}}
-        "/dev/{{item.0.vgname}}/{{item.0.cachelvname}}"
+    lvconvert -y --type cache-pool
+       {% if item.0.cachemetalvname is defined %} 
+        --poolmetadata {{ item.0.vgname }}/{{ item.0.cachemetalvname }}
+       {% else %}
+       --poolmetadata {{ item.0.vgname }}/{{ item.0.cachelvname }}_meta
+       {% endif %}
+       --poolmetadataspare n
+       --cachemode {{item.0.cachemode | default('writethrough')}}
+       "{{item.0.vgname}}/{{item.0.cachelvname}}"
   loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((checkpool_attrs is not none and checkpool_attrs.results) or default([]))) | list }}"
   when: item.1.stdout.find('C') != 0
 
 # Run lvs -a -o +devices to see the cache settings
 - name: Convert an existing logical volume to a cache LV
   command: >
-     lvconvert -y --type cache --cachepool "/dev/{{item.0.vgname}}/{{item.0.cachelvname}}"
-     "/dev/{{item.0.vgname}}/{{item.0.cachetarget | default(item.0.cachethinpoolname)}}"
+    lvconvert -y --type cache --cachepool {{ item.0.vgname }}/{{ item.0.cachelvname }}
+    {{ item.0.vgname }}/{{ item.0.cachetarget | default(item.0.cachethinpoolname) }}
   loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((datapoolcache_attrs is not none and datapoolcache_attrs.results) or default([]))) | list }}"
   loop_control:
-   index_var: index
+    index_var: index
   #check if the LV exists and is not yet converted to a cache volume 
   when: datapool_attrs.results[index].stdout is defined and datapool_attrs.results[index].stdout|length>0 and item.1.stdout.find(item.0.cachelvname) == -1
 

--- a/roles/backend_setup/tasks/cache_setup.yml
+++ b/roles/backend_setup/tasks/cache_setup.yml
@@ -23,9 +23,10 @@
 
 - name: Check if logical volume exists and is backed by the cache pool
   shell: >
-    lvs -a --options 'pool_lv' --noheadings {{ item.vgname }}/{{ item.cachetarget | default(item.cachethinpoolname) }} | grep cache
+    lvs -a --options 'data_lv,pool_lv' --separator "|" --noheadings  {{item.vgname}}/{{item.cachetarget | default(item.cachethinpoolname)}} 2>/dev/null|
+       awk -F '|'   '{ gsub(/^\s*\[/,"",$1);gsub(/\]\|?$/,"",$1);if(length($2)>0){ print "echo "$2}else if(length($1)>0){ print "lvs -a --noheadings --options 'pool_lv' {{item.vgname}}/"$1}}'|
+       bash|sed 's/^ *//;s/$//'
   register: datapoolcache_attrs
-  failed_when: false
   with_items: "{{ gluster_infra_cache_vars }}"
 
 - name: Change attributes of LV
@@ -100,7 +101,7 @@
 - name: Convert logical volume to a cache pool LV
   command: >
     lvconvert -y --type cache-pool
-       {% if item.0.cachemetalvname is defined %} 
+       {% if item.0.cachemetalvname is defined %}
         --poolmetadata {{ item.0.vgname }}/{{ item.0.cachemetalvname }}
        {% else %}
        --poolmetadata {{ item.0.vgname }}/{{ item.0.cachelvname }}_meta

--- a/roles/backend_setup/tasks/cache_setup.yml
+++ b/roles/backend_setup/tasks/cache_setup.yml
@@ -52,7 +52,7 @@
       {{- output | to_json -}}
   when: gluster_infra_cache_vars is defined and gluster_infra_cache_vars is not none and gluster_infra_cache_vars|length >0
 
-- name: Make sure meta and cache pv's exists in volume group
+- name: Make sure meta and cache pvs exists in volume group
   register: gluster_changed_vgs
   lvg:
     state: present

--- a/roles/backend_setup/tasks/cache_setup.yml
+++ b/roles/backend_setup/tasks/cache_setup.yml
@@ -6,14 +6,6 @@
 # Extend the existing volume group with the SSD (assuming SSD is used for
 # caching)
 
-# - name: Extend volume group
-#   lvg:
-#      state: present
-#      vg: "{{ item.vgname }}"
-#      pvs: "{{ item.cachedisk }}"
-#      pv_options: "--dataalignment 256K"
-#   with_items: "{{ gluster_infra_cache_vars }}"
-
 - name: Check if cachepool exists
   shell: "lvs --options 'lv_attr' -a --noheadings {{item.vgname}}/{{item.cachelvname}}| sed 's/^ *//;s/$//'"    
   register: checkpool_attrs
@@ -46,13 +38,6 @@
   loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((datapool_attrs is not none and datapool_attrs.results) or default([]))) | list }}"
   when: item.1.stdout is defined and item.1.stdout|length>0
 
-
-- debug: 
-   var: gluster_infra_cache_vars
-
-- debug: 
-   var: checkpoolmeta_attrs
-
 - include_tasks: get_vg_groupings.yml
   vars: 
    volume_groups: >-
@@ -66,9 +51,6 @@
       {%- endfor -%}
       {{- output | to_json -}}
   when: gluster_infra_cache_vars is defined and gluster_infra_cache_vars is not none and gluster_infra_cache_vars|length >0    
-
-- debug: 
-   var: gluster_volumes_by_groupname
 
 - name: Make sure meta and cache pv's exists in volume group
   register: gluster_changed_vgs
@@ -89,9 +71,6 @@
    filter: 'ansible_lvm'
   when: gluster_changed_vgs.changed 
 
-# - meta: end_play
-
-
 - name: Create LV for cache
   lvol:
      state: present
@@ -106,15 +85,6 @@
   #Sorry, no shrinking of cache-ans_thinpool3 without force=yes.
   when: item.1.stdout.find('C') != 0
   loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((checkpool_attrs is not none and checkpool_attrs.results) or default([]))) | list }}"
-
-# - name: Make sure meta pv's exists in volume group
-#   lvg:
-#      state: present
-#      vg: "{{ item.0.vgname }}"
-#      pvs: "{{ item.0.meta_pvs }}"
-#      pv_options: "--dataalignment 256K"
-#   loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((checkpoolmeta_attrs is not none and checkpoolmeta_attrs.results) or default([])))| list }}"
-#   when: item.0.meta_pvs is defined and (item.1.stdout is not defined or item.1.stdout.find('e') != 0)
 
 - name: Create metadata LV for cache
   lvol:

--- a/roles/backend_setup/tasks/cache_setup.yml
+++ b/roles/backend_setup/tasks/cache_setup.yml
@@ -16,7 +16,7 @@
   register: checkpoolmeta_attrs
   with_items: "{{ gluster_infra_cache_vars }}"
 
-- name: Check if logical data volume
+- name: Check if logical data volume exists
   shell: lvs -a --options 'lv_attr' --noheading {{item.vgname}}/{{ item.cachetarget | default(item.cachethinpoolname) }} | sed 's/^ *//;s/$//'
   register: datapool_attrs
   with_items: "{{ gluster_infra_cache_vars }}"
@@ -71,6 +71,18 @@
     filter: 'ansible_lvm'
   when: gluster_changed_vgs.changed
 
+
+- name: Create metadata LV for cache
+  lvol:
+    state: present
+    vg: "{{ item.0.vgname }}"
+    lv: "{{ item.0.cachemetalvname | default(item.0.cachelvname ~ '_meta') }}"
+    size: "{{ item.0.cachemetalvsize }}"
+    pvs: "{{ ((item.0.meta_pvs is defined and item.0.meta_pvs) or item.0.cachedisk) | default('') }}"
+    opts: "{{ ((item.0.meta_opts is defined and item.0.meta_opts) or item.0.opts) | default('') }}"
+  loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((checkpoolmeta_attrs is not none and checkpoolmeta_attrs.results) or default([])))| list }}"
+  when: item.1.stdout is not defined or item.1.stdout.find('e') != 0  
+
 - name: Create LV for cache
   lvol:
     state: present
@@ -85,17 +97,6 @@
   #Sorry, no shrinking of cache-ans_thinpool3 without force=yes.
   when: item.1.stdout.find('C') != 0
   loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((checkpool_attrs is not none and checkpool_attrs.results) or default([]))) | list }}"
-
-- name: Create metadata LV for cache
-  lvol:
-    state: present
-    vg: "{{ item.0.vgname }}"
-    lv: "{{ item.0.cachemetalvname | default(item.0.cachelvname ~ '_meta') }}"
-    size: "{{ item.0.cachemetalvsize }}"
-    pvs: "{{ ((item.0.meta_pvs is defined and item.0.meta_pvs) or item.0.cachedisk) | default('') }}"
-    opts: "{{ ((item.0.meta_opts is defined and item.0.meta_opts) or item.0.opts) | default('') }}"
-  loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((checkpoolmeta_attrs is not none and checkpoolmeta_attrs.results) or default([])))| list }}"
-  when: item.1.stdout is not defined or item.1.stdout.find('e') != 0
 
 #Command on LV ans_vg/cache-ans_thinpool2 does not accept LV type cachepool
 - name: Convert logical volume to a cache pool LV

--- a/roles/backend_setup/tasks/cache_setup.yml
+++ b/roles/backend_setup/tasks/cache_setup.yml
@@ -6,13 +6,13 @@
 # Extend the existing volume group with the SSD (assuming SSD is used for
 # caching)
 
-- name: Extend volume group
-  lvg:
-     state: present
-     vg: "{{ item.vgname }}"
-     pvs: "{{ item.cachedisk }}"
-     pv_options: "--dataalignment 256K"
-  with_items: "{{ gluster_infra_cache_vars }}"
+# - name: Extend volume group
+#   lvg:
+#      state: present
+#      vg: "{{ item.vgname }}"
+#      pvs: "{{ item.cachedisk }}"
+#      pv_options: "--dataalignment 256K"
+#   with_items: "{{ gluster_infra_cache_vars }}"
 
 - name: Check if cachepool exists
   shell: "lvs --options 'lv_attr' -a --noheadings {{item.vgname}}/{{item.cachelvname}}| sed 's/^ *//;s/$//'"    
@@ -46,6 +46,52 @@
   loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((datapool_attrs is not none and datapool_attrs.results) or default([]))) | list }}"
   when: item.1.stdout is defined and item.1.stdout|length>0
 
+
+- debug: 
+   var: gluster_infra_cache_vars
+
+- debug: 
+   var: checkpoolmeta_attrs
+
+- include_tasks: get_vg_groupings.yml
+  vars: 
+   volume_groups: >-
+      {%- set output=[] -%}
+      {%- for cnf in gluster_infra_cache_vars -%}
+      {%- if cnf is defined and cnf is not none and cnf.vgname is defined            
+            and (cnf.cachedisk is defined or cnf.meta_pvs is defined)
+      -%}
+      {{- output.append({"vgname": cnf.vgname, "pvname": (cnf.cachedisk|default('') ~ ',' ~ (cnf.meta_pvs|default(''))).split(',') | select | list | unique | join(',')}) -}}
+      {%- endif -%}
+      {%- endfor -%}
+      {{- output | to_json -}}
+  when: gluster_infra_cache_vars is defined and gluster_infra_cache_vars is not none and gluster_infra_cache_vars|length >0    
+
+- debug: 
+   var: gluster_volumes_by_groupname
+
+- name: Make sure meta and cache pv's exists in volume group
+  register: gluster_changed_vgs
+  lvg:
+     state: present
+     vg: "{{ (item.value | first).vgname }}"
+     pvs: "{{ item.value | json_query('[].pvname') | unique | join(',') }}"
+     pv_options: "--dataalignment 256K"  
+  loop: "{{ gluster_volumes_by_groupname | dict2items }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_volumes_by_groupname is defined and gluster_volumes_by_groupname is not none and gluster_volumes_by_groupname|length >0 
+   and item.value|length>0
+
+- name: update LVM fact's
+  setup: 
+   filter: 'ansible_lvm'
+  when: gluster_changed_vgs.changed 
+
+# - meta: end_play
+
+
 - name: Create LV for cache
   lvol:
      state: present
@@ -61,14 +107,14 @@
   when: item.1.stdout.find('C') != 0
   loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((checkpool_attrs is not none and checkpool_attrs.results) or default([]))) | list }}"
 
-- name: Make sure meta pv's exists in volume group
-  lvg:
-     state: present
-     vg: "{{ item.0.vgname }}"
-     pvs: "{{ item.0.meta_pvs }}"
-     pv_options: "--dataalignment 256K"
-  loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((checkpoolmeta_attrs is not none and checkpoolmeta_attrs.results) or default([])))| list }}"
-  when: item.0.meta_pvs is defined and (item.1.stdout is not defined or item.1.stdout.find('e') != 0)
+# - name: Make sure meta pv's exists in volume group
+#   lvg:
+#      state: present
+#      vg: "{{ item.0.vgname }}"
+#      pvs: "{{ item.0.meta_pvs }}"
+#      pv_options: "--dataalignment 256K"
+#   loop: "{{ ((gluster_infra_cache_vars is not none and gluster_infra_cache_vars) or default([])) | zip(((checkpoolmeta_attrs is not none and checkpoolmeta_attrs.results) or default([])))| list }}"
+#   when: item.0.meta_pvs is defined and (item.1.stdout is not defined or item.1.stdout.find('e') != 0)
 
 - name: Create metadata LV for cache
   lvol:

--- a/roles/backend_setup/tasks/fscreate.yml
+++ b/roles/backend_setup/tasks/fscreate.yml
@@ -27,7 +27,7 @@
    {% endif %}
   register: lvt_device_exists
   with_items: "{{ gluster_infra_lv_logicalvols }}"
-  when: item is not none
+  when: gluster_infra_lv_logicalvols is defined and item is not none
 
 # We support only XFS. Filesysem options sw, su are specific to XFS
 - name: Create filesystem on thin logical vols
@@ -55,7 +55,7 @@
    {% endif %}
   register: lv_device_exists
   with_items: "{{ gluster_infra_thick_lvs }}"  
-  when: item is not none
+  when: gluster_infra_thick_lvs is defined and item is not none
 
 - name: Create filesystem on thick logical vols
   filesystem:

--- a/roles/backend_setup/tasks/get_vg_groupings.yml
+++ b/roles/backend_setup/tasks/get_vg_groupings.yml
@@ -1,6 +1,4 @@
-
-- debug: 
-   var: volume_groups
+---
 
 - name: Group devices by volume group name, including existing devices
   set_fact:
@@ -35,12 +33,6 @@
    {% endfor %}
   register: vg_device_exists
   loop: "{{gluster_volumes_by_groupname_pre | dict2items}}"
-
-- debug: 
-    var: gluster_volumes_by_groupname_pre
-
-- debug: 
-    var: vg_device_exists
 
 - name: Filter none-existing devices
   set_fact:

--- a/roles/backend_setup/tasks/get_vg_groupings.yml
+++ b/roles/backend_setup/tasks/get_vg_groupings.yml
@@ -1,0 +1,62 @@
+
+- debug: 
+   var: volume_groups
+
+- name: Group devices by volume group name, including existing devices
+  set_fact:
+   gluster_volumes_by_groupname_pre: >-
+    {%- set output={} -%}
+    {%- for grouper, devicesConf in volume_groups | groupby('vgname') -%}
+      {%- set confs=[] -%}    
+      {%- for deviceConf in devicesConf -%}
+        {%- if deviceConf.pvname is defined -%}
+          {%- for device in deviceConf.pvname.split(',') -%}
+            {%- set deviceConfCln=dict(devicesConf | first) -%}
+            {{- deviceConfCln.__setitem__('pvname',device | trim) -}}
+            {{- confs.append(deviceConfCln) -}}
+          {%- endfor -%}
+        {%- endif -%}
+      {%- endfor -%}
+      {{- output.__setitem__(grouper, confs) -}}      
+    {%- endfor -%}
+    {%- if  hostvars[inventory_hostname].ansible_lvm is defined and hostvars[inventory_hostname].ansible_lvm.pvs is defined -%}
+      {%- for device, pvs in hostvars[inventory_hostname].ansible_lvm.pvs.iteritems() -%}
+        {%- if pvs.vg in output and output[pvs.vg] | selectattr('pvname','equalto',device) | list | count == 0 -%}
+          {{- output[pvs.vg].append({'pvname':device, 'vgname':pvs.vg }) -}}
+        {%- endif -%}
+      {%- endfor -%}
+    {%- endif -%}
+    {{- output | to_json -}}    
+
+- name: Check if vg block device exists
+  shell: >
+   {% for pvsname in item.value | json_query('[].pvname')  %}
+   test -b {{ pvsname }} && echo "1" || echo  "0";
+   {% endfor %}
+  register: vg_device_exists
+  loop: "{{gluster_volumes_by_groupname_pre | dict2items}}"
+
+- debug: 
+    var: gluster_volumes_by_groupname_pre
+
+- debug: 
+    var: vg_device_exists
+
+- name: Filter none-existing devices
+  set_fact:
+   gluster_volumes_by_groupname: >-
+    {%- set output={} -%}
+    {%- for vgname, devicesConf in gluster_volumes_by_groupname_pre.iteritems() -%}
+      {%- for item in vg_device_exists.results | json_query('[?item.key==`' ~ vgname ~ '`]') -%}
+        {%- set confs=[] -%}    
+        {%- for vgConfig in item.item.value -%}
+            {%- if item.stdout_lines[loop.index0] == "1" -%}
+              {%- set vgConfigCln=dict(item.item.value | first) -%}
+              {{- vgConfigCln.__setitem__('pvname',vgConfig.pvname) -}}
+              {{- confs.append(vgConfigCln) -}}
+            {%- endif -%}
+        {%- endfor -%}
+        {{- output.__setitem__(vgname, confs) -}}
+      {%- endfor -%}
+    {%- endfor -%}
+    {{- output | to_json -}}

--- a/roles/backend_setup/tasks/get_vg_groupings.yml
+++ b/roles/backend_setup/tasks/get_vg_groupings.yml
@@ -18,7 +18,7 @@
       {{- output.__setitem__(grouper, confs) -}}      
     {%- endfor -%}
     {%- if  hostvars[inventory_hostname].ansible_lvm is defined and hostvars[inventory_hostname].ansible_lvm.pvs is defined -%}
-      {%- for device, pvs in hostvars[inventory_hostname].ansible_lvm.pvs.iteritems() -%}
+      {%- for device, pvs in hostvars[inventory_hostname].ansible_lvm.pvs.items() -%}
         {%- if pvs.vg in output and output[pvs.vg] | selectattr('pvname','equalto',device) | list | count == 0 -%}
           {{- output[pvs.vg].append({'pvname':device, 'vgname':pvs.vg }) -}}
         {%- endif -%}
@@ -38,7 +38,7 @@
   set_fact:
    gluster_volumes_by_groupname: >-
     {%- set output={} -%}
-    {%- for vgname, devicesConf in gluster_volumes_by_groupname_pre.iteritems() -%}
+    {%- for vgname, devicesConf in gluster_volumes_by_groupname_pre.items() -%}
       {%- for item in vg_device_exists.results | json_query('[?item.key==`' ~ vgname ~ '`]') -%}
         {%- set confs=[] -%}    
         {%- for vgConfig in item.item.value -%}

--- a/roles/backend_setup/tasks/mount.yml
+++ b/roles/backend_setup/tasks/mount.yml
@@ -30,6 +30,7 @@
   no_log: true
 
 - name: Mount the vdo devices (If any)
+  register: lvmount_vdo
   mount:
      path: "{{ item.path }}"
      state: mounted
@@ -40,6 +41,7 @@
   when: vdo_devs|length > 0 and item.vgname in vdo_devs
 
 - name: Mount the devices
+  register: lvmount
   mount:
      path: "{{ item.path }}"
      state: mounted
@@ -48,6 +50,11 @@
      src: "{{ item.uuid }}"
   with_items: "{{ mount_devices_with_uuid }}"
   when: item.vgname not in vdo_devs
+
+- name: update mount fact's
+  setup: 
+   filter: 'ansible_mounts'
+  when: lvmount.changed or lvmount_vdo.changed
 
 - name: Set Gluster specific SeLinux context on the bricks
   sefcontext:

--- a/roles/backend_setup/tasks/thick_lv_create.yml
+++ b/roles/backend_setup/tasks/thick_lv_create.yml
@@ -63,6 +63,7 @@
     size: "{{ item.size }}"
     pvs: "{{ item.pvs | default() }}"
     opts: "{{ item.opts | default() }}"
+    shrink: "{{ item.shrink | default(true) }}"
   with_items: "{{ gluster_infra_thick_lvs }}"
   loop_control:
    index_var: index

--- a/roles/backend_setup/tasks/thick_lv_create.yml
+++ b/roles/backend_setup/tasks/thick_lv_create.yml
@@ -34,7 +34,7 @@
       {{- output | to_json -}}
   when: gluster_infra_thick_lvs is defined and gluster_infra_thick_lvs is not none and gluster_infra_thick_lvs|length >0 
 
-- name: Make sure thick pv's exists in volume group
+- name: Make sure thick pvs exists in volume group
   register: gluster_changed_vgs
   lvg:
      state: present

--- a/roles/backend_setup/tasks/thick_lv_create.yml
+++ b/roles/backend_setup/tasks/thick_lv_create.yml
@@ -20,6 +20,40 @@
   when: item.stdout_lines is defined and "0" in item.stdout_lines    
 
 
+- include_tasks: get_vg_groupings.yml
+  vars: 
+   volume_groups: >-
+      {%- set output=[] -%}
+      {%- for cnf in gluster_infra_thick_lvs -%}
+      {%- if cnf is defined and cnf is not none and cnf.vgname is defined
+            and (cnf.pvs is defined)
+      -%}
+      {{- output.append({"vgname": cnf.vgname, "pvname": (cnf.pvs|default('')).split(',') | select | list | unique | join(',')}) -}}
+      {%- endif -%}
+      {%- endfor -%}
+      {{- output | to_json -}}
+  when: gluster_infra_thick_lvs is defined and gluster_infra_thick_lvs is not none and gluster_infra_thick_lvs|length >0 
+
+- name: Make sure thick pv's exists in volume group
+  register: gluster_changed_vgs
+  lvg:
+     state: present
+     vg: "{{ (item.value | first).vgname }}"
+     pvs: "{{ item.value | json_query('[].pvname') | unique | join(',') }}"
+     pv_options: "--dataalignment 256K"
+  loop: "{{ gluster_volumes_by_groupname | dict2items }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_volumes_by_groupname is defined and gluster_volumes_by_groupname is not none and gluster_volumes_by_groupname|length >0 
+   and item.value|length>0  
+
+- name: update LVM fact's
+  setup: 
+   filter: 'ansible_lvm'
+  when: gluster_changed_vgs.changed    
+
+
 # Create a thick logical volume.
 - name: Create thick logical volume
   lvol:

--- a/roles/backend_setup/tasks/thick_lv_create.yml
+++ b/roles/backend_setup/tasks/thick_lv_create.yml
@@ -60,10 +60,10 @@
     state: present
     vg: "{{ item.vgname }}"
     lv: "{{ item.lvname }}"
-    size: "{{ item.size }}"
+    size: "{{ item.size | default('100%FREE') }}"
     pvs: "{{ item.pvs | default() }}"
     opts: "{{ item.opts | default() }}"
-    shrink: "{{ item.shrink | default(true) }}"
+    shrink: "{{ item.shrink if item.shrink is defined and item.shrink is not none else true }}"
   with_items: "{{ gluster_infra_thick_lvs }}"
   loop_control:
    index_var: index

--- a/roles/backend_setup/tasks/thin_pool_create.yml
+++ b/roles/backend_setup/tasks/thin_pool_create.yml
@@ -75,7 +75,7 @@
 # block of tasks, which is executed when there are valid pools and pool items are configured.
 # also it checks if the pool doesn't already exists
 
-- name: Make sure meta and pool pv's exists in volume group
+- name: Make sure meta and pool pvs exists in volume group
   register: gluster_changed_vgs
   lvg:
      state: present

--- a/roles/backend_setup/tasks/thin_pool_create.yml
+++ b/roles/backend_setup/tasks/thin_pool_create.yml
@@ -38,9 +38,6 @@
   when: item is not none
 
 
-- debug:
-   var: lvtp_device_exists
-
 - name: Record for missing devices for phase 2
   set_fact:
    gluster_phase2_has_missing_devices: true
@@ -59,72 +56,6 @@
    and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
    and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
 
-
-- name: Create a LV thinpool-data
-  debug:
-     var: item.pvs.split(",") | default([]) | map("trim") | list
-  loop: "{{ gluster_infra_thinpools }}"
-  loop_control:
-   index_var: index
-  when: > 
-   gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 
-   and item is defined and item is not none and item.thinpoolname is defined and item.thinpoolname is defined  and item.vgname is defined   
-   and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
-   and (thinpool_attrs.results[index].stdout is not defined or thinpool_attrs.results[index].stdout.find("t") != 0)
-   and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
-
-
-- debug:
-   var: hostvars[inventory_hostname].ansible_lvm.vgs
-
-- name: Create a LV thinpool-data222222
-  debug:
-     #var: (hostvars[inventory_hostname].ansible_lvm.pvs | dict2items | json_query('[?value.vg==`'+item.vgname+'`].key') +
-     var:  (item.pvs|default('')).split(',') | map('trim') | list | union((item.meta_pvs | default('')).split(',') | map('trim') | list) | union(hostvars[inventory_hostname].ansible_lvm.pvs | dict2items | json_query('[?value.vg==`'+item.vgname+'`].key') ) | select | list | unique 
-     #var:  (item.pvs|default('')).split(',') | map('trim') | list | union((item.meta_pvs | default('')).split(',') | map('trim') | list) | unique
-     #
-     #| json_query('*|[?@.vg==`ans_vg2`]')
-   #   var: hostvars[inventory_hostname].ansible_lvm.pvs 
-  loop: "{{ gluster_infra_thinpools }}"
-  loop_control:
-   index_var: index
-  when: > 
-   gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 
-   and item is defined and item is not none and item.thinpoolname is defined and item.thinpoolname is defined  and item.vgname is defined   
-   and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
-   and (thinpool_attrs.results[index].stdout is not defined or thinpool_attrs.results[index].stdout.find("t") != 0)
-   and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
-
-- name: Create a LV thinpool-data33333
-  debug:
-     var: item.vgname
-   #   var: hostvars[inventory_hostname].ansible_lvm.pvs 
-  loop: "{{ gluster_infra_thinpools }}"
-  loop_control:
-   index_var: index
-  when: > 
-   gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 
-   and item is defined and item is not none and item.thinpoolname is defined and item.thinpoolname is defined  and item.vgname is defined   
-   and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
-   and (thinpool_attrs.results[index].stdout is not defined or thinpool_attrs.results[index].stdout.find("t") != 0)
-   and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
-
-
-
-- name: Make sure meta pv's exists in volume group
-  debug:
-     var: item.meta_pvs.split(",") | map("trim") | list
-  loop: "{{ gluster_infra_thinpools }}"
-  loop_control:
-   index_var: index
-  when: > 
-   gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 
-   and item is defined and item is not none and item.thinpoolname is defined and item.thinpoolname is defined  and item.vgname is defined   
-   and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
-   and (thinpool_attrs.results[index].stdout is not defined or thinpool_attrs.results[index].stdout.find("t") != 0)
-   and item.meta_pvs is defined
-
-
 - include_tasks: get_vg_groupings.yml
   vars: 
    volume_groups: >-
@@ -140,8 +71,6 @@
       {{- output | to_json -}}
   when: gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 
 
-
-
 # https://github.com/ansible/ansible/issues/13262
 # block of tasks, which is executed when there are valid pools and pool items are configured.
 # also it checks if the pool doesn't already exists
@@ -152,7 +81,6 @@
      state: present
      vg: "{{ (item.value | first).vgname }}"
      pvs: "{{ item.value | json_query('[].pvname') | unique | join(',') }}"
-     #pvs: "{{ (item.pvs|default('')).split(',') | map('trim') | list | union((item.meta_pvs | default('')).split(',') | map('trim') | list) | union(hostvars[inventory_hostname].ansible_lvm.pvs | dict2items | json_query('[?value.vg==`'+item.vgname+'`].key') ) | select | list | unique | join(',') }}"     
      pv_options: "--dataalignment 256K"  
   loop: "{{ gluster_volumes_by_groupname | dict2items }}"
   loop_control:
@@ -161,15 +89,10 @@
    gluster_volumes_by_groupname is defined and gluster_volumes_by_groupname is not none and gluster_volumes_by_groupname|length >0 
    and item.value|length>0
 
-# - meta: end_play
-
-
 - name: update LVM fact's
   setup: 
    filter: 'ansible_lvm'
   when: gluster_changed_vgs.changed 
-
-
 
 - name: Create a LV thinpool-data
   lvol:
@@ -191,7 +114,6 @@
    and (thinpool_attrs.results[index].stdout is not defined or thinpool_attrs.results[index].stdout.find("t") != 0)
    and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
 
- 
 
 - name: Create a LV thinpool-meta
   lvol:

--- a/roles/backend_setup/tasks/thin_pool_create.yml
+++ b/roles/backend_setup/tasks/thin_pool_create.yml
@@ -24,9 +24,11 @@
 
 - name: Check if thin-pool block devices exists
   shell: >
-   {%if (item.pvs is defined) %}
-   {% for pvsname in item.pvs.split(",")  %}
+   {%if (item.pvs is defined) or (item.meta_pvs is defined)  %}
+   {% for pvsname in (item.pvs|default('')).split(",") | union((item.meta_pvs|default('')).split(","))  %}
+   {% if pvsname|length>0 %}
    test -b {{ pvsname }} && echo "1" || echo  "0";
+   {% endif %}
    {% endfor %}
    {% else %}
    echo "1"
@@ -34,6 +36,10 @@
   register: lvtp_device_exists
   with_items: "{{ gluster_infra_thinpools }}"
   when: item is not none
+
+
+- debug:
+   var: lvtp_device_exists
 
 - name: Record for missing devices for phase 2
   set_fact:
@@ -54,9 +60,117 @@
    and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
 
 
+- name: Create a LV thinpool-data
+  debug:
+     var: item.pvs.split(",") | default([]) | map("trim") | list
+  loop: "{{ gluster_infra_thinpools }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 
+   and item is defined and item is not none and item.thinpoolname is defined and item.thinpoolname is defined  and item.vgname is defined   
+   and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
+   and (thinpool_attrs.results[index].stdout is not defined or thinpool_attrs.results[index].stdout.find("t") != 0)
+   and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
+
+
+- debug:
+   var: hostvars[inventory_hostname].ansible_lvm.vgs
+
+- name: Create a LV thinpool-data222222
+  debug:
+     #var: (hostvars[inventory_hostname].ansible_lvm.pvs | dict2items | json_query('[?value.vg==`'+item.vgname+'`].key') +
+     var:  (item.pvs|default('')).split(',') | map('trim') | list | union((item.meta_pvs | default('')).split(',') | map('trim') | list) | union(hostvars[inventory_hostname].ansible_lvm.pvs | dict2items | json_query('[?value.vg==`'+item.vgname+'`].key') ) | select | list | unique 
+     #var:  (item.pvs|default('')).split(',') | map('trim') | list | union((item.meta_pvs | default('')).split(',') | map('trim') | list) | unique
+     #
+     #| json_query('*|[?@.vg==`ans_vg2`]')
+   #   var: hostvars[inventory_hostname].ansible_lvm.pvs 
+  loop: "{{ gluster_infra_thinpools }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 
+   and item is defined and item is not none and item.thinpoolname is defined and item.thinpoolname is defined  and item.vgname is defined   
+   and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
+   and (thinpool_attrs.results[index].stdout is not defined or thinpool_attrs.results[index].stdout.find("t") != 0)
+   and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
+
+- name: Create a LV thinpool-data33333
+  debug:
+     var: item.vgname
+   #   var: hostvars[inventory_hostname].ansible_lvm.pvs 
+  loop: "{{ gluster_infra_thinpools }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 
+   and item is defined and item is not none and item.thinpoolname is defined and item.thinpoolname is defined  and item.vgname is defined   
+   and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
+   and (thinpool_attrs.results[index].stdout is not defined or thinpool_attrs.results[index].stdout.find("t") != 0)
+   and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
+
+
+
+- name: Make sure meta pv's exists in volume group
+  debug:
+     var: item.meta_pvs.split(",") | map("trim") | list
+  loop: "{{ gluster_infra_thinpools }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 
+   and item is defined and item is not none and item.thinpoolname is defined and item.thinpoolname is defined  and item.vgname is defined   
+   and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
+   and (thinpool_attrs.results[index].stdout is not defined or thinpool_attrs.results[index].stdout.find("t") != 0)
+   and item.meta_pvs is defined
+
+
+- include_tasks: get_vg_groupings.yml
+  vars: 
+   volume_groups: >-
+      {%- set output=[] -%}
+      {%- for cnf in gluster_infra_thinpools -%}
+      {%- if cnf is defined and cnf is not none and cnf.thinpoolname is defined and cnf.vgname is defined
+            and (thinpool_attrs.results[loop.index0].stdout is not defined or thinpool_attrs.results[loop.index0].stdout.find("t") != 0) 
+            and (cnf.meta_pvs is defined or cnf.pvs is defined)
+      -%}
+      {{- output.append({"vgname": cnf.vgname, "pvname": (cnf.pvs|default('') ~ ',' ~ (cnf.meta_pvs|default(''))).split(',') | select | list | unique | join(',')}) -}}
+      {%- endif -%}
+      {%- endfor -%}
+      {{- output | to_json -}}
+  when: gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 
+
+
+
 # https://github.com/ansible/ansible/issues/13262
 # block of tasks, which is executed when there are valid pools and pool items are configured.
 # also it checks if the pool doesn't already exists
+
+- name: Make sure meta and pool pv's exists in volume group
+  register: gluster_changed_vgs
+  lvg:
+     state: present
+     vg: "{{ (item.value | first).vgname }}"
+     pvs: "{{ item.value | json_query('[].pvname') | unique | join(',') }}"
+     #pvs: "{{ (item.pvs|default('')).split(',') | map('trim') | list | union((item.meta_pvs | default('')).split(',') | map('trim') | list) | union(hostvars[inventory_hostname].ansible_lvm.pvs | dict2items | json_query('[?value.vg==`'+item.vgname+'`].key') ) | select | list | unique | join(',') }}"     
+     pv_options: "--dataalignment 256K"  
+  loop: "{{ gluster_volumes_by_groupname | dict2items }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_volumes_by_groupname is defined and gluster_volumes_by_groupname is not none and gluster_volumes_by_groupname|length >0 
+   and item.value|length>0
+
+# - meta: end_play
+
+
+- name: update LVM fact's
+  setup: 
+   filter: 'ansible_lvm'
+  when: gluster_changed_vgs.changed 
+
+
+
 - name: Create a LV thinpool-data
   lvol:
      state: present
@@ -77,21 +191,7 @@
    and (thinpool_attrs.results[index].stdout is not defined or thinpool_attrs.results[index].stdout.find("t") != 0)
    and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
 
-- name: Make sure meta pv's exists in volume group
-  lvg:
-     state: present
-     vg: "{{ item.vgname }}"
-     pvs: "{{ item.meta_pvs }}"
-     pv_options: "--dataalignment 256K"
-  with_items: "{{ gluster_infra_thinpools }}"
-  loop_control:
-   index_var: index
-  when: > 
-   gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0 
-   and item is defined and item is not none and item.thinpoolname is defined and item.thinpoolname is defined  and item.vgname is defined   
-   and lvtp_device_exists.results[index].stdout_lines is defined and "0" not in lvtp_device_exists.results[index].stdout_lines
-   and (thinpool_attrs.results[index].stdout is not defined or thinpool_attrs.results[index].stdout.find("t") != 0)
-   and item.meta_pvs is defined
+ 
 
 - name: Create a LV thinpool-meta
   lvol:

--- a/roles/backend_setup/tasks/thin_volume_create.yml
+++ b/roles/backend_setup/tasks/thin_volume_create.yml
@@ -4,9 +4,11 @@
 
 - name: Check if thin-lv block devices exists
   shell: >
-   {%if (item.pvs is defined) %}
-   {% for pvsname in item.pvs.split(",")  %}
+   {% if (item.pvs is defined) or (item.meta_pvs is defined)  %}
+   {% for pvsname in (item.pvs|default('')).split(",") | union((item.meta_pvs|default('')).split(","))  %}
+   {% if pvsname|length>0 %}
    test -b {{ pvsname }} && echo "1" || echo  "0";
+   {% endif %}
    {% endfor %}
    {% else %}
    echo "1"
@@ -33,7 +35,46 @@
    gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none   
    and lvt_device_exists.results[index].stdout_lines is defined and "0" not in lvt_device_exists.results[index].stdout_lines
    and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
-   
+
+
+- include_tasks: get_vg_groupings.yml
+  vars: 
+   volume_groups: >-
+      {%- set output=[] -%}
+      {%- for cnf in gluster_infra_lv_logicalvols -%}
+      {%- if cnf is defined and cnf is not none and cnf.vgname is defined
+            and (thinlv_attrs.results[loop.index0].stdout is not defined or thinlv_attrs.results[loop.index0].stdout.find("V") != 0)
+            and (cnf.meta_pvs is defined or cnf.pvs is defined)
+      -%}
+      {{- output.append({"vgname": cnf.vgname, "pvname": (cnf.pvs|default('') ~ ',' ~ (cnf.meta_pvs|default(''))).split(',') | select | list | unique | join(',')}) -}}
+      {%- endif -%}
+      {%- endfor -%}
+      {{- output | to_json -}}
+  when: gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 
+
+
+- name: Make sure meta and thin pv's exists in volume group
+  register: gluster_changed_vgs
+  lvg:
+     state: present
+     vg: "{{ (item.value | first).vgname }}"
+     pvs: "{{ item.value | json_query('[].pvname') | unique | join(',') }}"
+     #pvs: "{{ (item.pvs|default('')).split(',') | map('trim') | list | union((item.meta_pvs | default('')).split(',') | map('trim') | list) | union(hostvars[inventory_hostname].ansible_lvm.pvs | dict2items | json_query('[?value.vg==`'+item.vgname+'`].key') ) | select | list | unique | join(',') }}"
+     pv_options: "--dataalignment 256K"
+  loop: "{{ gluster_volumes_by_groupname | dict2items }}"
+  loop_control:
+   index_var: index
+  when: > 
+   gluster_volumes_by_groupname is defined and gluster_volumes_by_groupname is not none and gluster_volumes_by_groupname|length >0 
+   and item.value|length>0
+
+- name: update LVM fact's
+  setup: 
+   filter: 'ansible_lvm'
+  when: gluster_changed_vgs.changed 
+
+# - meta: end_play
+
 
 - name: Create a LV thinlv-data
   lvol:
@@ -54,20 +95,6 @@
    and  (thinlv_attrs.results[index].stdout is not defined or thinlv_attrs.results[index].stdout.find("V") != 0)
    and ((item.opts is defined and "raid" in item.opts) or item.meta_pvs is defined or item.meta_opts is defined)
 
-- name: Make sure meta pv's exists in volume group
-  lvg:
-     state: present
-     vg: "{{ item.vgname }}"
-     pvs: "{{ item.meta_pvs }}"
-     pv_options: "--dataalignment 256K"
-  with_items: "{{ gluster_infra_lv_logicalvols }}"
-  loop_control:
-   index_var: index
-  when: > 
-   gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none   
-   and lvt_device_exists.results[index].stdout_lines is defined and "0" not in lvt_device_exists.results[index].stdout_lines
-   and (thinlv_attrs.results[index].stdout is not defined or thinlv_attrs.results[index].stdout.find("V") != 0)
-   and (item.meta_pvs is defined)
 
 - name: Create a LV thinlv-meta
   lvol:

--- a/roles/backend_setup/tasks/thin_volume_create.yml
+++ b/roles/backend_setup/tasks/thin_volume_create.yml
@@ -137,6 +137,7 @@
      thinpool: "{{ item.thinpool }}"
      size: "{{ item.lvsize }}"
      pvs: "{{ item.pvs | default() }}"
+     shrink: "{{ item.shrink | default(true) }}"
      opts: >
       {{ item.opts | default() }}      
   with_items: "{{ gluster_infra_lv_logicalvols }}"

--- a/roles/backend_setup/tasks/thin_volume_create.yml
+++ b/roles/backend_setup/tasks/thin_volume_create.yml
@@ -53,7 +53,7 @@
   when: gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 
 
 
-- name: Make sure meta and thin pv's exists in volume group
+- name: Make sure meta and thin pvs exists in volume group
   register: gluster_changed_vgs
   lvg:
      state: present

--- a/roles/backend_setup/tasks/thin_volume_create.yml
+++ b/roles/backend_setup/tasks/thin_volume_create.yml
@@ -59,7 +59,6 @@
      state: present
      vg: "{{ (item.value | first).vgname }}"
      pvs: "{{ item.value | json_query('[].pvname') | unique | join(',') }}"
-     #pvs: "{{ (item.pvs|default('')).split(',') | map('trim') | list | union((item.meta_pvs | default('')).split(',') | map('trim') | list) | union(hostvars[inventory_hostname].ansible_lvm.pvs | dict2items | json_query('[?value.vg==`'+item.vgname+'`].key') ) | select | list | unique | join(',') }}"
      pv_options: "--dataalignment 256K"
   loop: "{{ gluster_volumes_by_groupname | dict2items }}"
   loop_control:
@@ -72,8 +71,6 @@
   setup: 
    filter: 'ansible_lvm'
   when: gluster_changed_vgs.changed 
-
-# - meta: end_play
 
 
 - name: Create a LV thinlv-data

--- a/roles/backend_setup/tasks/vg_create.yml
+++ b/roles/backend_setup/tasks/vg_create.yml
@@ -40,7 +40,6 @@
      gluster_infra_disktype == 'RAID6' or
      gluster_infra_disktype == 'RAID10' or
      gluster_infra_disktype == 'RAID5'
-     
 
 - include_tasks: get_vg_groupings.yml
   vars: 
@@ -66,8 +65,8 @@
     pv_options: "--dataalignment {{ item.value.pv_dataalign | default(pv_dataalign) }}"
     # pesize is 4m by default for JBODs
     pesize: "{{ vg_pesize | default(4) }}"
-  loop: "{{gluster_volumes_by_groupname | dict2items}}"
-  when: item.value|length>0
+  loop: "{{gluster_volumes_by_groupname | default({}) | dict2items}}"
+  when: gluster_volumes_by_groupname is defined and item.value|length>0
   
 - name: update LVM fact's
   setup: 

--- a/roles/backend_setup/tasks/vg_create.yml
+++ b/roles/backend_setup/tasks/vg_create.yml
@@ -40,157 +40,18 @@
      gluster_infra_disktype == 'RAID6' or
      gluster_infra_disktype == 'RAID10' or
      gluster_infra_disktype == 'RAID5'
-
-
-# - name: Check if vg block device exists
-#   shell: test -b {{ item.pvname }} && echo "1" || echo  "0"
-#   register: vg_device_exists
-#   with_items: "{{ gluster_infra_volume_groups }}"
-#   when: item.pvname is defined
-  
-# - name: Record for missing devices for phase 2
-#   set_fact:
-#    gluster_phase2_has_missing_devices: true
-#   loop: "{{ vg_device_exists.results }}"
-#   when: item.stdout is defined and item.stdout == "0"
-
-
-- debug: 
-   var: hostvars[inventory_hostname].ansible_lvm.pvs
-- debug: 
-   var: "{{ gluster_infra_volume_groups| groupby('vgname') }}"
-
-# "gluster_volumes_by_groupname_pre": {
-#         "ans_vg2": [
-#             {
-#                 "pvname": "/dev/sdg1",
-#                 "vgname": "ans_vg2"
-#             },
-#             {
-#                 "pvname": "/dev/sdd1",
-#                 "vgname": "ans_vg2"
-#             },
-#             {
-#                 "pvname": "/dev/sde1",
-#                 "vgname": "ans_vg2"
-#             },
-#             {
-#                 "pvname": "/dev/sdh1",
-#                 "vgname": "ans_vg2"
-#             }
-#         ],
-#         "ans_vg3": [
-#             {
-#                 "pvname": "/dev/sdf1",
-#                 "vgname": "ans_vg3"
-#             },
-#             {
-#                 "pvname": "/dev/sdi1",
-#                 "vgname": "ans_vg3"
-#             }
-#         ]
-#     }
-# - name: Group devices by volume group name, including existing devices
-#   set_fact:
-#    gluster_volumes_by_groupname_pre: >-
-#     {%- set output={} -%}
-#     {%- for grouper, devicesConf in gluster_infra_volume_groups| groupby('vgname') -%}
-#       {%- set confs=[] -%}    
-#       {%- for deviceConf in devicesConf -%}
-#         {%- if deviceConf.pvname is defined -%}
-#           {%- for device in deviceConf.pvname.split(',') -%}
-#             {%- set deviceConfCln=dict(devicesConf | first) -%}
-#             {{- deviceConfCln.__setitem__('pvname',device | trim) -}}
-#             {{- confs.append(deviceConfCln) -}}
-#           {%- endfor -%}
-#         {%- endif -%}
-#       {%- endfor -%}
-#       {{- output.__setitem__(grouper, confs) -}}      
-#     {%- endfor -%}
-#     {%- if  hostvars[inventory_hostname].ansible_lvm is defined and  hostvars[inventory_hostname].ansible_lvm.pvs is defined -%}
-#       {%- for device, pvs in hostvars[inventory_hostname].ansible_lvm.pvs.iteritems() -%}
-#         {%- if pvs.vg in output and output[pvs.vg] | selectattr('pvname','equalto',device) | list | count == 0 -%}
-#           {{- output[pvs.vg].append({'pvname':device, 'vgname':pvs.vg }) -}}
-#         {%- endif -%}
-#       {%- endfor -%}
-#     {%- endif -%}
-#     {{- output | to_json -}}
-
-
-# - debug: 
-#    var: gluster_volumes_by_groupname_pre
-#   #  var: "{{gluster_volumes_by_groupname_pre}}"
-
-# - debug: 
-#    msg: "KEY: {{ item.key }}, VALUE: {{ item.value | json_query('[].pvname') | unique | join(',') }}"
-#   loop: "{{gluster_volumes_by_groupname_pre | dict2items}}"   
-
-
-# - name: Check if vg block device exists
-#   shell: >
-#    {% for pvsname in item.value | json_query('[].pvname') | unique  %}
-#    test -b {{ pvsname }} && echo "1" || echo  "0";
-#    {% endfor %}
-#   register: vg_device_exists
-#   loop: "{{gluster_volumes_by_groupname_pre | dict2items}}" 
-
-# - debug: 
-#    var: vg_device_exists
-  
-# - name: Record for missing devices for phase 2
-#   set_fact:
-#    gluster_phase2_has_missing_devices: true
-#   loop: "{{ vg_device_exists.results }}"
-#   when: item.stdout_lines is defined and "0" in item.stdout_lines
-
-# - debug: 
-#    var: gluster_phase2_has_missing_devices
-
-# - debug:
-#    var: vg_device_exists.results | json_query('[?item.key==`ans_vg3`] | [0]')
-
-# - name: Filter none-existing devices
-#   set_fact:
-#    gluster_volumes_by_groupname: >-
-#     {%- set output={} -%}
-#     {%- for vgname, devicesConf in gluster_volumes_by_groupname_pre.iteritems() -%}
-#       {%- for item in vg_device_exists.results | json_query('[?item.key==`' ~ vgname ~ '`]') -%}
-#         {%- set confs=[] -%}    
-#         {%- for vgConfig in item.item.value -%}
-#             {%- if item.stdout_lines[loop.index0] == "1" -%}
-#               {%- set vgConfigCln=dict(item.item.value | first) -%}
-#               {{- vgConfigCln.__setitem__('pvname',vgConfig.pvname) -}}
-#               {{- confs.append(vgConfigCln) -}}
-#             {%- endif -%}
-#         {%- endfor -%}
-#         {{- output.__setitem__(vgname, confs) -}}
-#       {% endfor %}
-#     {% endfor %}
-#     {{- output | to_json -}}
-
+     
 
 - include_tasks: get_vg_groupings.yml
   vars: 
    volume_groups: "{{ gluster_infra_volume_groups }}"
   when: gluster_infra_volume_groups is defined and gluster_infra_volume_groups is not none and gluster_infra_volume_groups|length >0 
 
-- debug: 
-   var: gluster_volumes_by_groupname
-
-- debug: 
-   var: vg_device_exists   
-
 - name: Record for missing devices for phase 2
   set_fact:
    gluster_phase2_has_missing_devices: true
   loop: "{{ vg_device_exists.results }}"
   when: item.stdout_lines is defined and "0" in item.stdout_lines
-
-- debug: 
-   var: gluster_phase2_has_missing_devices
-
-
-# - meta: end_play
 
 # Tasks to create a volume group
 # The devices in `pvs' can be a regular device or a VDO device
@@ -211,8 +72,4 @@
 - name: update LVM fact's
   setup: 
    filter: 'ansible_lvm'
-  when: gluster_changed_vgs.changed 
-
-- debug: 
-   var: hostvars[inventory_hostname].ansible_lvm.pvs
   when: gluster_changed_vgs.changed 

--- a/roles/backend_setup/tasks/vg_create.yml
+++ b/roles/backend_setup/tasks/vg_create.yml
@@ -41,31 +41,158 @@
      gluster_infra_disktype == 'RAID10' or
      gluster_infra_disktype == 'RAID5'
 
+
+# - name: Check if vg block device exists
+#   shell: test -b {{ item.pvname }} && echo "1" || echo  "0"
+#   register: vg_device_exists
+#   with_items: "{{ gluster_infra_volume_groups }}"
+#   when: item.pvname is defined
+  
+# - name: Record for missing devices for phase 2
+#   set_fact:
+#    gluster_phase2_has_missing_devices: true
+#   loop: "{{ vg_device_exists.results }}"
+#   when: item.stdout is defined and item.stdout == "0"
+
+
+- debug: 
+   var: hostvars[inventory_hostname].ansible_lvm.pvs
+- debug: 
+   var: "{{ gluster_infra_volume_groups| groupby('vgname') }}"
+
+# "gluster_volumes_by_groupname_pre": {
+#         "ans_vg2": [
+#             {
+#                 "pvname": "/dev/sdg1",
+#                 "vgname": "ans_vg2"
+#             },
+#             {
+#                 "pvname": "/dev/sdd1",
+#                 "vgname": "ans_vg2"
+#             },
+#             {
+#                 "pvname": "/dev/sde1",
+#                 "vgname": "ans_vg2"
+#             },
+#             {
+#                 "pvname": "/dev/sdh1",
+#                 "vgname": "ans_vg2"
+#             }
+#         ],
+#         "ans_vg3": [
+#             {
+#                 "pvname": "/dev/sdf1",
+#                 "vgname": "ans_vg3"
+#             },
+#             {
+#                 "pvname": "/dev/sdi1",
+#                 "vgname": "ans_vg3"
+#             }
+#         ]
+#     }
+- name: Group devices by volume group name, including existing devices
+  set_fact:
+   gluster_volumes_by_groupname_pre: >-
+    {%- set output={} -%}
+    {%- for grouper, devicesConf in gluster_infra_volume_groups| groupby('vgname') -%}
+      {%- set confs=[] -%}    
+      {%- for deviceConf in devicesConf -%}
+        {%- if deviceConf.pvname is defined -%}
+          {%- for device in deviceConf.pvname.split(',') -%}
+            {%- set deviceConfCln=dict(devicesConf | first) -%}
+            {{- deviceConfCln.__setitem__('pvname',device | trim) -}}
+            {{- confs.append(deviceConfCln) -}}
+          {%- endfor -%}
+        {%- endif -%}
+      {%- endfor -%}
+      {{- output.__setitem__(grouper, confs) -}}      
+    {%- endfor -%}
+    {%- if  hostvars[inventory_hostname].ansible_lvm is defined and  hostvars[inventory_hostname].ansible_lvm.pvs is defined -%}
+      {%- for device, pvs in hostvars[inventory_hostname].ansible_lvm.pvs.iteritems() -%}
+        {%- if pvs.vg in output and output[pvs.vg] | selectattr('pvname','equalto',device) | list | count == 0 -%}
+          {{- output[pvs.vg].append({'pvname':device, 'vgname':pvs.vg }) -}}
+        {%- endif -%}
+      {%- endfor -%}
+    {%- endif -%}
+    {{- output | to_json -}}
+
+
+- debug: 
+   var: gluster_volumes_by_groupname_pre
+  #  var: "{{gluster_volumes_by_groupname_pre}}"
+
+- debug: 
+   msg: "KEY: {{ item.key }}, VALUE: {{ item.value | json_query('[].pvname') | unique | join(',') }}"
+  loop: "{{gluster_volumes_by_groupname_pre | dict2items}}"   
+
+
 - name: Check if vg block device exists
-  shell: test -b {{ item.pvname }} && echo "1" || echo  "0"
+  shell: >
+   {% for pvsname in item.value | json_query('[].pvname') | unique  %}
+   test -b {{ pvsname }} && echo "1" || echo  "0";
+   {% endfor %}
   register: vg_device_exists
-  with_items: "{{ gluster_infra_volume_groups }}"
-  when: item.pvname is defined
+  loop: "{{gluster_volumes_by_groupname_pre | dict2items}}" 
+
+- debug: 
+   var: vg_device_exists
   
 - name: Record for missing devices for phase 2
   set_fact:
    gluster_phase2_has_missing_devices: true
   loop: "{{ vg_device_exists.results }}"
-  when: item.stdout is defined and item.stdout == "0"
+  when: item.stdout_lines is defined and "0" in item.stdout_lines
 
+- debug: 
+   var: gluster_phase2_has_missing_devices
+
+- debug:
+   var: vg_device_exists.results | json_query('[?item.key==`ans_vg3`] | [0]')
+
+- name: Filter none-existing devices
+  set_fact:
+   gluster_volumes_by_groupname: >-
+    {%- set output={} -%}
+    {%- for vgname, devicesConf in gluster_volumes_by_groupname_pre.iteritems() -%}
+      {%- for item in vg_device_exists.results | json_query('[?item.key==`' ~ vgname ~ '`]') -%}
+        {%- set confs=[] -%}    
+        {%- for vgConfig in item.item.value -%}
+            {%- if item.stdout_lines[loop.index0] == "1" -%}
+              {%- set vgConfigCln=dict(item.item.value | first) -%}
+              {{- vgConfigCln.__setitem__('pvname',vgConfig.pvname) -}}
+              {{- confs.append(vgConfigCln) -}}
+            {%- endif -%}
+        {%- endfor -%}
+        {{- output.__setitem__(vgname, confs) -}}
+      {% endfor %}
+    {% endfor %}
+    {{- output | to_json -}}
+
+- debug: 
+   var: gluster_volumes_by_groupname
+
+# - meta: end_play
 
 # Tasks to create a volume group
 # The devices in `pvs' can be a regular device or a VDO device
+# Please take note; only the first item per volume group will define the actual configuraton!
+#TODO: fix pesize // {{ ((item.value | first).vg_pesize || vg_pesize) | default(4) }}
 - name: Create volume groups
+  register: gluster_changed_vgs
   lvg:
     state: present
-    vg: "{{ item.vgname }}"
-    pvs: "{{ item.pvname }}"
-    pv_options: "--dataalignment {{ pv_dataalign }}"
+    vg: "{{ (item.value | first).vgname }}"
+    pvs: "{{ item.value | json_query('[].pvname') | unique | join(',') }}"
+    pv_options: "--dataalignment {{ item.value.pv_dataalign | default(pv_dataalign) }}"
     # pesize is 4m by default for JBODs
     pesize: "{{ vg_pesize | default(4) }}"
-  with_items: "{{ gluster_infra_volume_groups }}"
-  loop_control:
-   index_var: index
-  when: item.pvname is defined and vg_device_exists.results[index].stdout is defined and vg_device_exists.results[index].stdout == "1"
+  loop: "{{gluster_volumes_by_groupname | dict2items}}"
+  
+- name: update LVM fact's
+  setup: 
+   filter: 'ansible_lvm'
+  when: gluster_changed_vgs.changed 
 
+- debug: 
+   var: hostvars[inventory_hostname].ansible_lvm.pvs
+  when: gluster_changed_vgs.changed 

--- a/roles/backend_setup/tasks/vg_create.yml
+++ b/roles/backend_setup/tasks/vg_create.yml
@@ -90,53 +90,96 @@
 #             }
 #         ]
 #     }
-- name: Group devices by volume group name, including existing devices
-  set_fact:
-   gluster_volumes_by_groupname_pre: >-
-    {%- set output={} -%}
-    {%- for grouper, devicesConf in gluster_infra_volume_groups| groupby('vgname') -%}
-      {%- set confs=[] -%}    
-      {%- for deviceConf in devicesConf -%}
-        {%- if deviceConf.pvname is defined -%}
-          {%- for device in deviceConf.pvname.split(',') -%}
-            {%- set deviceConfCln=dict(devicesConf | first) -%}
-            {{- deviceConfCln.__setitem__('pvname',device | trim) -}}
-            {{- confs.append(deviceConfCln) -}}
-          {%- endfor -%}
-        {%- endif -%}
-      {%- endfor -%}
-      {{- output.__setitem__(grouper, confs) -}}      
-    {%- endfor -%}
-    {%- if  hostvars[inventory_hostname].ansible_lvm is defined and  hostvars[inventory_hostname].ansible_lvm.pvs is defined -%}
-      {%- for device, pvs in hostvars[inventory_hostname].ansible_lvm.pvs.iteritems() -%}
-        {%- if pvs.vg in output and output[pvs.vg] | selectattr('pvname','equalto',device) | list | count == 0 -%}
-          {{- output[pvs.vg].append({'pvname':device, 'vgname':pvs.vg }) -}}
-        {%- endif -%}
-      {%- endfor -%}
-    {%- endif -%}
-    {{- output | to_json -}}
+# - name: Group devices by volume group name, including existing devices
+#   set_fact:
+#    gluster_volumes_by_groupname_pre: >-
+#     {%- set output={} -%}
+#     {%- for grouper, devicesConf in gluster_infra_volume_groups| groupby('vgname') -%}
+#       {%- set confs=[] -%}    
+#       {%- for deviceConf in devicesConf -%}
+#         {%- if deviceConf.pvname is defined -%}
+#           {%- for device in deviceConf.pvname.split(',') -%}
+#             {%- set deviceConfCln=dict(devicesConf | first) -%}
+#             {{- deviceConfCln.__setitem__('pvname',device | trim) -}}
+#             {{- confs.append(deviceConfCln) -}}
+#           {%- endfor -%}
+#         {%- endif -%}
+#       {%- endfor -%}
+#       {{- output.__setitem__(grouper, confs) -}}      
+#     {%- endfor -%}
+#     {%- if  hostvars[inventory_hostname].ansible_lvm is defined and  hostvars[inventory_hostname].ansible_lvm.pvs is defined -%}
+#       {%- for device, pvs in hostvars[inventory_hostname].ansible_lvm.pvs.iteritems() -%}
+#         {%- if pvs.vg in output and output[pvs.vg] | selectattr('pvname','equalto',device) | list | count == 0 -%}
+#           {{- output[pvs.vg].append({'pvname':device, 'vgname':pvs.vg }) -}}
+#         {%- endif -%}
+#       {%- endfor -%}
+#     {%- endif -%}
+#     {{- output | to_json -}}
 
 
-- debug: 
-   var: gluster_volumes_by_groupname_pre
-  #  var: "{{gluster_volumes_by_groupname_pre}}"
+# - debug: 
+#    var: gluster_volumes_by_groupname_pre
+#   #  var: "{{gluster_volumes_by_groupname_pre}}"
 
-- debug: 
-   msg: "KEY: {{ item.key }}, VALUE: {{ item.value | json_query('[].pvname') | unique | join(',') }}"
-  loop: "{{gluster_volumes_by_groupname_pre | dict2items}}"   
+# - debug: 
+#    msg: "KEY: {{ item.key }}, VALUE: {{ item.value | json_query('[].pvname') | unique | join(',') }}"
+#   loop: "{{gluster_volumes_by_groupname_pre | dict2items}}"   
 
 
-- name: Check if vg block device exists
-  shell: >
-   {% for pvsname in item.value | json_query('[].pvname') | unique  %}
-   test -b {{ pvsname }} && echo "1" || echo  "0";
-   {% endfor %}
-  register: vg_device_exists
-  loop: "{{gluster_volumes_by_groupname_pre | dict2items}}" 
+# - name: Check if vg block device exists
+#   shell: >
+#    {% for pvsname in item.value | json_query('[].pvname') | unique  %}
+#    test -b {{ pvsname }} && echo "1" || echo  "0";
+#    {% endfor %}
+#   register: vg_device_exists
+#   loop: "{{gluster_volumes_by_groupname_pre | dict2items}}" 
 
-- debug: 
-   var: vg_device_exists
+# - debug: 
+#    var: vg_device_exists
   
+# - name: Record for missing devices for phase 2
+#   set_fact:
+#    gluster_phase2_has_missing_devices: true
+#   loop: "{{ vg_device_exists.results }}"
+#   when: item.stdout_lines is defined and "0" in item.stdout_lines
+
+# - debug: 
+#    var: gluster_phase2_has_missing_devices
+
+# - debug:
+#    var: vg_device_exists.results | json_query('[?item.key==`ans_vg3`] | [0]')
+
+# - name: Filter none-existing devices
+#   set_fact:
+#    gluster_volumes_by_groupname: >-
+#     {%- set output={} -%}
+#     {%- for vgname, devicesConf in gluster_volumes_by_groupname_pre.iteritems() -%}
+#       {%- for item in vg_device_exists.results | json_query('[?item.key==`' ~ vgname ~ '`]') -%}
+#         {%- set confs=[] -%}    
+#         {%- for vgConfig in item.item.value -%}
+#             {%- if item.stdout_lines[loop.index0] == "1" -%}
+#               {%- set vgConfigCln=dict(item.item.value | first) -%}
+#               {{- vgConfigCln.__setitem__('pvname',vgConfig.pvname) -}}
+#               {{- confs.append(vgConfigCln) -}}
+#             {%- endif -%}
+#         {%- endfor -%}
+#         {{- output.__setitem__(vgname, confs) -}}
+#       {% endfor %}
+#     {% endfor %}
+#     {{- output | to_json -}}
+
+
+- include_tasks: get_vg_groupings.yml
+  vars: 
+   volume_groups: "{{ gluster_infra_volume_groups }}"
+  when: gluster_infra_volume_groups is defined and gluster_infra_volume_groups is not none and gluster_infra_volume_groups|length >0 
+
+- debug: 
+   var: gluster_volumes_by_groupname
+
+- debug: 
+   var: vg_device_exists   
+
 - name: Record for missing devices for phase 2
   set_fact:
    gluster_phase2_has_missing_devices: true
@@ -146,30 +189,6 @@
 - debug: 
    var: gluster_phase2_has_missing_devices
 
-- debug:
-   var: vg_device_exists.results | json_query('[?item.key==`ans_vg3`] | [0]')
-
-- name: Filter none-existing devices
-  set_fact:
-   gluster_volumes_by_groupname: >-
-    {%- set output={} -%}
-    {%- for vgname, devicesConf in gluster_volumes_by_groupname_pre.iteritems() -%}
-      {%- for item in vg_device_exists.results | json_query('[?item.key==`' ~ vgname ~ '`]') -%}
-        {%- set confs=[] -%}    
-        {%- for vgConfig in item.item.value -%}
-            {%- if item.stdout_lines[loop.index0] == "1" -%}
-              {%- set vgConfigCln=dict(item.item.value | first) -%}
-              {{- vgConfigCln.__setitem__('pvname',vgConfig.pvname) -}}
-              {{- confs.append(vgConfigCln) -}}
-            {%- endif -%}
-        {%- endfor -%}
-        {{- output.__setitem__(vgname, confs) -}}
-      {% endfor %}
-    {% endfor %}
-    {{- output | to_json -}}
-
-- debug: 
-   var: gluster_volumes_by_groupname
 
 # - meta: end_play
 
@@ -187,6 +206,7 @@
     # pesize is 4m by default for JBODs
     pesize: "{{ vg_pesize | default(4) }}"
   loop: "{{gluster_volumes_by_groupname | dict2items}}"
+  when: item.value|length>0
   
 - name: update LVM fact's
   setup: 


### PR DESCRIPTION
It appears commit: https://github.com/ansible/ansible/commit/3e303bea4c305994addcd739e1848d9637112512
changes the semantics of the ansible lvg module significantly. where the lvg module, just used to extend a volume group with a device, it now by default reduces the volume group to the configured pvs'es. This causes most tasks to fail. Unfortunate there is no option to restore the old behaviour of just extending the VG with a parameter.
The difference in running these tasks in ansible 2.7 vs. 2.8 is significant;
```yaml
     - lvg:
        state: present
        vg: "vg_test1"
        pvs: "/dev/sdd1"
    - lvg:
        state: present
        vg: "vg_test1"
        pvs: "/dev/sdg1"
````
in 2.7 this would yield to a volume group of vg_test1 consisting of /dev/sdd1 and /dev/sdg1
in 2.8 this would yield to a volume group of vg_test1 consisting of only /dev/sdg1, since the VG vg_test1 is reduced in the second task to only /dev/sdg1


This PR aims to solve this issue, by resolving all available members of the volume group. This should restore the old behaviour, where devices are just added to the volume group. This with the disadvantage the reduction of VG should be handled as separate task, if this is a requirement.