### PR TITLE
Changed multipath conf location

### DIFF
--- a/roles/backend_setup/tasks/blacklist_mpath_devices.yml
+++ b/roles/backend_setup/tasks/blacklist_mpath_devices.yml
@@ -1,10 +1,19 @@
 ---
 # This play is for blacklist devices
+- name: Flush all empty multipath devices
+  shell: multipath -F
+
+- name: Create /etc/multipath/conf.d if doesn't exists
+  file:
+    path: /etc/multipath/conf.d
+    recurse: yes
+    state: directory
 
 - name: "Blacklist gluster multipath devices"
   no_log: true
   blockinfile:
-    path: /etc/multipath.conf
+    path: /etc/multipath/conf.d/blacklist.conf
+    create: yes
     state: present
     block: |
       blacklist {

--- a/roles/backend_setup/tasks/main.yml
+++ b/roles/backend_setup/tasks/main.yml
@@ -8,6 +8,12 @@
 # https://wiki.gentoo.org/wiki/LVM/en
 # https://serverfault.com/questions/981694/why-does-xfs-uses-lvm-cache-chunk-size-instead-the-raid5-setup-for-sunit-swidth
 
+# Blacklist multipath devices
+- name: Blacklist multipath devices
+  import_tasks: blacklist_mpath_devices.yml
+  when: blacklist_mpath_devices is defined
+  tags:
+    - blacklistdevices
 
 # Gather facts to determine the distribution
 - name: Gather facts to determine the OS distribution
@@ -153,10 +159,3 @@
   when: gluster_infra_tangservers is defined
   tags:
     - bindtang
-
-# Blacklist multipath devices
-- name: Blacklist multipath devices
-  import_tasks: blacklist_mpath_devices.yml
-  when: blacklist_mpath_devices is defined
-  tags:
-    - blacklistdevices


### PR DESCRIPTION
RHBZ#1807814

As multipath.conf managed by VDSM, custom changes related to multipath need to move to different place, so that in case of upgrade the changes will be retained. So movinf the changes to  /etc/multipath/conf.d/blacklist.conf