### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ respective sub-roles directory.
 |--------------------------|-------|-----------------------|-----------------------------------|
 | gluster_infra_vdo || UNDEF | Mandatory argument if vdo has to be setup. Key/Value pairs have to be given. See examples for syntax. |
 | gluster_infra_disktype | JBOD / RAID6 / RAID10  | UNDEF   | Backend disk type. |
-| gluster_infra_diskcount || UNDEF | RAID diskcount, can be ignored if disktype is JBOD  |
+| gluster_infra_diskcount || UNDEF | Ignored if disktype is JBOD.  The number of data disks in your RAID6/RAID10 array.  Set this value to 10 if you're using RAID6 with 12 total disks (10 data + 2 parity disks).  |
 | gluster_infra_volume_groups  || UNDEF | Key/value pairs of vgname and pvname. pvname can be comma-separated values if more than a single pv is needed for a vg. See below for syntax. This variable is mandatory when PVs are not specified in the LVs |
 | gluster_infra_stripe_unit_size || UNDEF| Stripe unit size (KiB). *DO NOT* including trailing 'k' or 'K'  |
 | gluster_infra_lv_poolmetadatasize || 16G | Metadata size for LV, recommended value 16G is used by default. That value can be overridden by setting the variable. Include the unit [G\|M\|K] |


### PR DESCRIPTION
Provide additional information that 'gluster_infra_diskcount' should be set to the number of *data* disks in the RAID6/RAID10 array.  e.g. Set this value to 10 if your using RAID6 with 12 total disks (10 data + 2 parity disks).