### PR TITLE
Blacklist playbook doesn't stop when identifying LUKS device

### DIFF
--- a/roles/backend_setup/tasks/blacklist_mpath_devices.yml
+++ b/roles/backend_setup/tasks/blacklist_mpath_devices.yml
@@ -3,7 +3,7 @@
 - name: Find whether device is a luks device
   shell: cryptsetup isLuks /dev/{{ item }}
   register: result
-  ignore_errors: True
+  failed_when: result.rc == 0
   with_items: "{{ blacklist_mpath_devices }}"
   when: blacklist_mpath_devices is defined
 


### PR DESCRIPTION
Known Fact: LUKS device is not to be blacklisted.

Problem: blacklist playbook checks whether the given device is a LUKS device 
using the command 'cryptsetup isLuks <device>'. Return value of this
command is 0, when its a LUKS device.
 Ideally, in this case the execution should stop with error, but actually, it doesn't stops

Fix: 'cryptsetup isLuks <device>' returns 0, if its a LUKS device.
 Added a condition to fail when the return code is 0.
This means, the playbook will stop execution, when the device is a
LUKS device.