### PR TITLE
This fix addresses 2 issues - blacklisting with partition devices & fstab mount options for LUKS devices

### DIFF
--- a/roles/backend_setup/tasks/blacklist_mpath_devices.yml
+++ b/roles/backend_setup/tasks/blacklist_mpath_devices.yml
@@ -23,7 +23,7 @@
 
 - name: Get the UUID of the devices
   ignore_errors: True
-  shell: multipath -a /dev/{{ item }}
+  shell: multipath -a /dev/{{ item | regex_replace('[0-9]+$') }}
   register: dev_uuid
   with_items: "{{ blacklist_mpath_devices }}"
 

--- a/roles/backend_setup/tasks/main.yml
+++ b/roles/backend_setup/tasks/main.yml
@@ -55,7 +55,7 @@
   set_fact:
      vdo_devs: "{{ vdo_devs|default([]) + [ item.vgname ] }}"
   with_items: "{{ gluster_infra_volume_groups | default([]) }}"
-  when: item.pvname is defined and item.pvname is search("/dev/mapper/")
+  when: item.pvname is defined and item.pvname is search("/dev/mapper/vdo")
 
 # set lvm config
 - name: Configure LVM
@@ -123,7 +123,7 @@
   tags:
     - luksencrypt
 
-# Bind Tand server
+# Bind Tang server
 - name: Bind Tand server
   import_tasks: bind_tang_server.yml
   when: gluster_infra_tangservers is defined


### PR DESCRIPTION
This PR fixes 2 issues
1. Blacklisting with partition devices
2. fstab mount option for devices created on top of LUKS devices

Blacklisting with partition devices:
When the device name is listed as /dev/sdb1 ( for example ), blacklisting was trying to do 'multipath -a /dev/sdb1'
Now with regex pattern in the play, even with input device as /dev/sdb1, blacklisting will try 'multipath -a /dev/sdb'

fstab mount option for devices created on top of LUKS devices:
When using device name corresponding to LUKS device ( /dev/mapper/luks_sdc ), and enabling VDO on that
brick, adds the VDO options for all the bricks, as the earlier logic always considered whatever as '/dev/mapper/'
as VDO device. Now LUKS device is also created under '/dev/mapper' and that is considered as VDO device
as per that logic. Latest logic includes searching for VDO devices with patter '/dev/mapper/vdo', rather than
simple search of '/dev/mapper/