### PR TITLE
Create lvm exclude filter

### DIFF
--- a/roles/backend_setup/tasks/lvm_exclude_filter.yml
+++ b/roles/backend_setup/tasks/lvm_exclude_filter.yml
@@ -1,0 +1,10 @@
+---
+- name: Backup lvm.conf file
+  copy:
+    src: /etc/lvm/lvm.conf
+    dest: /backup
+
+- name: Remove the existing LVM filter
+  shell: >
+     sed -i /^filter/d /etc/lvm/lvm.conf
+     

--- a/roles/backend_setup/tasks/lvm_exclude_filter.yml
+++ b/roles/backend_setup/tasks/lvm_exclude_filter.yml
@@ -2,4 +2,5 @@
 - name: Remove the existing LVM filter
   shell: >
      sed -i /^filter/d /etc/lvm/lvm.conf
+  ignore_errors: yes
      

--- a/roles/backend_setup/tasks/lvm_exclude_filter.yml
+++ b/roles/backend_setup/tasks/lvm_exclude_filter.yml
@@ -1,9 +1,4 @@
 ---
-- name: Backup lvm.conf file
-  copy:
-    src: /etc/lvm/lvm.conf
-    dest: /backup
-
 - name: Remove the existing LVM filter
   shell: >
      sed -i /^filter/d /etc/lvm/lvm.conf

--- a/roles/backend_setup/tasks/main.yml
+++ b/roles/backend_setup/tasks/main.yml
@@ -63,8 +63,10 @@
   when: gluster_infra_lvm is defined
   tags:
     - lvmconfig
-
-
+    
+- name: Exclue LVM Filter rules
+  import_tasks: lvm_exclude_filter.yml
+  
 #phase #1
 - name: Create a vdo disk
   import_tasks: vdo_create.yml
@@ -101,7 +103,10 @@
   when: gluster_infra_mount_devices is defined and gluster_infra_mount_devices is not none
   tags:
     - mount
-
+    
+- name: Re-generate new LVM Filrer rules
+  import_tasks: regenerate_new_lvm_filter_rules.yml
+  
 # set kernel boot params for lvm volumes
 - name: Configure lvm kernel parameters
   import_tasks: lvm_kernelparams.yml

--- a/roles/backend_setup/tasks/main.yml
+++ b/roles/backend_setup/tasks/main.yml
@@ -8,6 +8,9 @@
 # https://wiki.gentoo.org/wiki/LVM/en
 # https://serverfault.com/questions/981694/why-does-xfs-uses-lvm-cache-chunk-size-instead-the-raid5-setup-for-sunit-swidth
 
+- name: Exclude LVM Filter rules
+  import_tasks: lvm_exclude_filter.yml
+ 
 # Blacklist multipath devices
 - name: Blacklist multipath devices
   import_tasks: blacklist_mpath_devices.yml
@@ -63,10 +66,7 @@
   when: gluster_infra_lvm is defined
   tags:
     - lvmconfig
-    
-- name: Exclue LVM Filter rules
-  import_tasks: lvm_exclude_filter.yml
-  
+      
 #phase #1
 - name: Create a vdo disk
   import_tasks: vdo_create.yml
@@ -103,9 +103,6 @@
   when: gluster_infra_mount_devices is defined and gluster_infra_mount_devices is not none
   tags:
     - mount
-    
-- name: Re-generate new LVM Filrer rules
-  import_tasks: regenerate_new_lvm_filter_rules.yml
   
 # set kernel boot params for lvm volumes
 - name: Configure lvm kernel parameters
@@ -134,3 +131,6 @@
   when: gluster_infra_tangservers is defined
   tags:
     - bindtang
+
+- name: Re-generate new LVM Filrer rules
+  import_tasks: regenerate_new_lvm_filter_rules.yml

--- a/roles/backend_setup/tasks/regenerate_new_lvm_filter_rules.yml
+++ b/roles/backend_setup/tasks/regenerate_new_lvm_filter_rules.yml
@@ -1,0 +1,4 @@
+---
+- name: Regenerate new LVM filter rules
+  shell: >
+    vdsm-tool config-lvm-filter -y  


### PR DESCRIPTION
Before RHHI-V Deployment , certain tasks (that might involve brick creation, or Day2 operation like creation of new volume, expanding the cluster or volume,) require  removal of   existing LVM filter

to avoid errors like " Device /dev/sdf excluded by a filter."