### PR TITLE
Create regenerate_new_lvm_filter_rules.yml

### DIFF
--- a/roles/backend_setup/tasks/regenerate_new_lvm_filter_rules.yml
+++ b/roles/backend_setup/tasks/regenerate_new_lvm_filter_rules.yml
@@ -1,0 +1,4 @@
+---
+- name: Regenerate new LVM filter rules
+  shell: >
+    vdsm-tool config-lvm-filter -y  


### PR DESCRIPTION
Post RHHI-V Deployment , certain tasks (that might involve brick creation, or Day2 operation like creation of new volume, expanding the cluster or volume,) require  removal of   existing LVM filter

to avoid errors like " Device /dev/sdf excluded by a filter."