### PR TITLE
Update bind_server.yml with newline character fix

### DIFF
--- a/roles/backend_setup/tasks/bind_tang_server.yml
+++ b/roles/backend_setup/tasks/bind_tang_server.yml
@@ -5,8 +5,7 @@
   no_log: true
   copy:
       dest: "/etc/root_key"
-      content: |
-        {{ rootpassphrase }}
+      content: "{{ rootpassphrase }}"
   when: gluster_infra_tangservers is defined
 
 - name: Download the advertisement from tang server for IPv4


### PR DESCRIPTION
 Binding to tang server fails as the passphrase includes newline character. this PR fixes that issue