### PR TITLE
Fixed issue in extend brick

### DIFF
--- a/roles/backend_setup/tasks/blacklist_mpath_devices.yml
+++ b/roles/backend_setup/tasks/blacklist_mpath_devices.yml
@@ -23,7 +23,7 @@
 
 - name: Get the UUID of the devices
   ignore_errors: True
-  shell: multipath -a /dev/{{ item | regex_replace('[0-9]+$') }}
+  shell: multipath -a /dev/{% if item.startswith('sd') %}{{ item | regex_replace('[0-9]+$') }}{% else %}{{ item }}{% endif %}
   register: dev_uuid
   with_items: "{{ blacklist_mpath_devices }}"
 


### PR DESCRIPTION
When a host has nvme disk unable to expand gluster brick because regular expression failing to apply for nvme disk.
added if condition to work for both nvme disk and normal disk
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1903905