### PR TITLE
Added check when thinpool size is specified

### DIFF
--- a/roles/backend_setup/tasks/thin_pool_create.yml
+++ b/roles/backend_setup/tasks/thin_pool_create.yml
@@ -232,7 +232,7 @@
 
 
 - name: Create a LV thinpool
-  command: "lvcreate -l {{ item.thinpoolsize | default('100%FREE') }} --options {% if item.raid is defined and item.raid is not none
+  command: "lvcreate {% if item.thinpoolsize is defined  %} -L {{ item.thinpoolsize }} {% else %} -l 100%FREE  {% endif %} --options {% if item.raid is defined and item.raid is not none
             and item.raid.level is defined and item.raid.devices is defined and item.raid.stripe is defined
             and item.raid.level in [0,5,6,10]%}
          {% if item.raid.level == 0 %}
@@ -286,7 +286,7 @@
 #end-block
 
 - name: Create a LV thinpool for similar device types
-  command: "lvcreate --type thin-pool --zero n -l {{ item.thinpoolsize | default('100%FREE') }} --chunksize {{ lv_chunksize }} --poolmetadatasize {{ item.poolmetadatasize + \"iB\" }} -n {{ item.thinpoolname }} {{ item.vgname }} "
+  command: "lvcreate --type thin-pool --zero n {% if item.thinpoolsize is defined  %} -L {{ item.thinpoolsize }} {% else %} -l 100%FREE  {% endif %} --chunksize {{ lv_chunksize }} --poolmetadatasize {{ item.poolmetadatasize + \"iB\" }} -n {{ item.thinpoolname }} {{ item.vgname }} "
   # lvol:
   #    state: present
   #    shrink: false


### PR DESCRIPTION
When thinpoolsize specified in the deployment inventory infra role fails as -l option only works with Number[PERCENT] as value & -L works with Size[m|UNIT]
hence added a check to handle appropriate condition.

Bug-Url: https://github.com/gluster/gluster-ansible-infra/issues/129