### PR TITLE
Removing to_json because before ansible v2.13 its returning dictionar…

### DIFF
--- a/roles/backend_setup/tasks/get_vg_groupings.yml
+++ b/roles/backend_setup/tasks/get_vg_groupings.yml
@@ -5,7 +5,7 @@
    gluster_volumes_by_groupname_pre: >-
     {%- set output={} -%}
     {%- for grouper, devicesConf in volume_groups | groupby('vgname') -%}
-      {%- set confs=[] -%}    
+      {%- set confs=[] -%}
       {%- for deviceConf in devicesConf -%}
         {%- if deviceConf.pvname is defined -%}
           {%- for device in deviceConf.pvname.split(',') -%}
@@ -15,7 +15,7 @@
           {%- endfor -%}
         {%- endif -%}
       {%- endfor -%}
-      {{- output.__setitem__(grouper, confs) -}}      
+      {{- output.__setitem__(grouper, confs) -}}
     {%- endfor -%}
     {%- if  hostvars[inventory_hostname].ansible_lvm is defined and hostvars[inventory_hostname].ansible_lvm.pvs is defined -%}
       {%- for device, pvs in hostvars[inventory_hostname].ansible_lvm.pvs.items() -%}
@@ -24,7 +24,7 @@
         {%- endif -%}
       {%- endfor -%}
     {%- endif -%}
-    {{- output | to_json -}}    
+    {{- output -}}
 
 - name: Check if vg block device exists
   shell: >
@@ -51,4 +51,4 @@
         {{- output.__setitem__(vgname, confs) -}}
       {%- endfor -%}
     {%- endfor -%}
-    {{- output | to_json -}}
+    {{- output -}}

--- a/roles/backend_setup/tasks/thick_lv_create.yml
+++ b/roles/backend_setup/tasks/thick_lv_create.yml
@@ -31,7 +31,7 @@
       {{- output.append({"vgname": cnf.vgname, "raid": cnf.raid | default() , "pvname": (cnf.pvs|default('')).split(',') | select | list | unique | join(',')}) -}}
       {%- endif -%}
       {%- endfor -%}
-      {{- output | to_json -}}
+      {{- output -}}
   when: gluster_infra_thick_lvs is defined and gluster_infra_thick_lvs is not none and gluster_infra_thick_lvs|length >0
 
 - name: Make sure thick pvs exists in volume group
@@ -129,4 +129,3 @@
   loop_control:
    index_var: index
   when: item is not none and lv_device_exists.results[index].stdout_lines is defined and "0" not in lv_device_exists.results[index].stdout_lines
-

--- a/roles/backend_setup/tasks/thin_pool_create.yml
+++ b/roles/backend_setup/tasks/thin_pool_create.yml
@@ -68,7 +68,7 @@
       {{- output.append({"vgname": cnf.vgname, "pvname": (cnf.pvs|default('') ~ ',' ~ (cnf.meta_pvs|default(''))).split(',') | select | list | unique | join(',')}) -}}
       {%- endif -%}
       {%- endfor -%}
-      {{- output | to_json -}}
+      {{- output -}}
   when: gluster_infra_thinpools is defined and gluster_infra_thinpools is not none and gluster_infra_thinpools|length >0
 
 # https://github.com/ansible/ansible/issues/13262
@@ -298,4 +298,3 @@
   #            --zero n"
   with_items: "{{ gluster_infra_thinpools }}"
   when: gluster_infra_thinpools is defined and item.raid is not defined
-

--- a/roles/backend_setup/tasks/thin_volume_create.yml
+++ b/roles/backend_setup/tasks/thin_volume_create.yml
@@ -49,7 +49,7 @@
       {{- output.append({"vgname": cnf.vgname, "pvname": (cnf.pvs|default('') ~ ',' ~ (cnf.meta_pvs|default(''))).split(',') | select | list | unique | join(',')}) -}}
       {%- endif -%}
       {%- endfor -%}
-      {{- output | to_json -}}
+      {{- output -}}
   when: gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0
 
 
@@ -151,4 +151,3 @@
    gluster_infra_lv_logicalvols is defined and gluster_infra_lv_logicalvols is not none and gluster_infra_lv_logicalvols|length >0 and item is defined and item is not none
    and lvt_device_exists.results[index].stdout_lines is defined and "0" not in lvt_device_exists.results[index].stdout_lines
    and ((item.opts is not defined or "raid" not in item.opts) and item.meta_pvs is not defined and item.meta_opts is not defined)
-


### PR DESCRIPTION
Actually, the original behavior of this function is to return a string but in ansible 2.12 was a mistake I guess. Now in ansible 2.13, the original behavior is back so we don't need to use to_json 

Refer Doc: https://github.com/ansible/ansible/issues/76443#issuecomment-984879201 
Bug:- https://github.com/gluster/gluster-ansible-infra/issues/135