### PR TITLE
Update vg_create.yml

### DIFF
--- a/roles/backend_setup/tasks/vg_create.yml
+++ b/roles/backend_setup/tasks/vg_create.yml
@@ -62,7 +62,7 @@
 #TODO: fix pesize // {{ ((item.value | first).vg_pesize || vg_pesize) | default(4) }}
 - name: Create volume groups
   register: gluster_changed_vgs
-  command: vgcreate --dataalignment {{ item.value.pv_dataalign | default(pv_dataalign) }} -s {{ vg_pesize | default(4) }} {{ (item.value | first).vgname }} {{ item.value | ovirt.ovirt.json_query('[].pvname') | unique | join(',') }}
+  command: vgcreate --dataalignment {{ item.value.pv_dataalign | default(pv_dataalign) }} -s {{ vg_pesize | default(4) }} {{ (item.value | first).vgname }} {{ item.value | ovirt.ovirt.json_query('[].pvname') | unique | join(' ') }}
  # lvg:
  #   state: present
  #   vg: "{{ (item.value | first).vgname }}"


### PR DESCRIPTION
When creating a volume group with multiple disks, it doesn't recognized using a ',' as a separator, it expects a ' ', an empty space.

Tested on Rocky Linux 9.3 and Debian 12.1